### PR TITLE
feat: Add Kaggle integration with GitHub Secrets

### DIFF
--- a/.github/workflows/kaggle-integration.yml
+++ b/.github/workflows/kaggle-integration.yml
@@ -1,0 +1,47 @@
+name: Kaggle Integration
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  kaggle-smoke-test:
+    runs-on: ubuntu-latest
+    env:
+      KAGGLE_USERNAME: ${{ secrets.KAGGLE_USERNAME }}
+      KAGGLE_KEY: ${{ secrets.KAGGLE_KEY }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Verify Kaggle secrets are available
+        run: |
+          if [ -z "${KAGGLE_USERNAME}" ] || [ -z "${KAGGLE_KEY}" ]; then
+            echo "KAGGLE_USERNAME and KAGGLE_KEY must be defined as repository secrets."
+            exit 1
+          fi
+
+      - name: Configure Kaggle credentials
+        run: |
+          mkdir -p ~/.kaggle
+          cat <<EOF > ~/.kaggle/kaggle.json
+          {
+            "username": "${KAGGLE_USERNAME}",
+            "key": "${KAGGLE_KEY}"
+          }
+          EOF
+          chmod 600 ~/.kaggle/kaggle.json
+
+      - name: Install Kaggle client
+        run: |
+          python -m pip install --upgrade pip
+          pip install kaggle
+
+      - name: Kaggle API smoke test
+        run: |
+          kaggle datasets list -s "titanic" | head -n 5

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,11 @@ poetry.lock
 # Environment
 .env
 .env.local
+.env.*
+
+# Kaggle credentials
+kaggle.json
+.kaggle/
 
 # Data (exclude large artifacts)
 data/raw/**/*.zip

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,6 @@
+# Security Policy
+
+## Secret Handling
+
+- Never commit API keys, tokens, or other secrets to this repository.
+- Kaggle credentials must only live in GitHub repository secrets (`KAGGLE_USERNAME`, `KAGGLE_KEY`) or in local untracked files such as `~/.kaggle/kaggle.json` or a `.env` file covered by `.gitignore`.

--- a/docs/kaggle-integration.md
+++ b/docs/kaggle-integration.md
@@ -1,0 +1,42 @@
+# Kaggle Integration
+
+## Continuous Integration
+
+- The workflow in `.github/workflows/kaggle-integration.yml` runs on `push`, `pull_request`, and manual `workflow_dispatch` events.
+- It expects `KAGGLE_USERNAME` and `KAGGLE_KEY` to be configured as GitHub repository secrets. These values are injected into the job environment and used to create `~/.kaggle/kaggle.json` on the runner.
+- The workflow installs the official Kaggle CLI and runs a smoke test (`kaggle datasets list -s "titanic" | head -n 5`) to verify that the credentials are valid.
+
+## Local Setup Options
+
+### Option A: `~/.kaggle/kaggle.json`
+
+1. Download your `kaggle.json` from Kaggle.
+2. Place it at `~/.kaggle/kaggle.json` and run `chmod 600 ~/.kaggle/kaggle.json`.
+3. Never commit this file. It is ignored via `.gitignore`.
+
+### Option B: `.env` + environment variables
+
+1. Create a local `.env` file (see `.env.example` for structure) and add:
+   ```bash
+   KAGGLE_USERNAME=your_username
+   KAGGLE_KEY=your_key
+   ```
+2. Keep the file untracked (covered by `.gitignore`).
+3. Export the values when needed or run the helper script below to materialize `kaggle.json` on demand.
+
+### Helper Script
+
+Use `scripts/setup_kaggle_creds.py` to generate the Kaggle config locally without hand-editing files:
+
+```bash
+python scripts/setup_kaggle_creds.py --env-file .env
+```
+
+- The script first checks real environment variables, then falls back to the provided `.env` file.
+- It writes `~/.kaggle/kaggle.json` with `0600` permissions so only your user can read it.
+
+## Security Reminders
+
+- Never commit `kaggle.json`, `.env`, or any other secret material.
+- Long-lived secrets belong either in local untracked files (for development) or in GitHub Secrets (for CI).
+- Rotate credentials immediately if accidental exposure is suspected.

--- a/scripts/setup_kaggle_creds.py
+++ b/scripts/setup_kaggle_creds.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Materialize Kaggle credentials locally without tracking secrets."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Dict
+
+
+def parse_env_file(path: Path) -> Dict[str, str]:
+    """Best-effort parser for KEY=VALUE lines inside a .env file."""
+    values: Dict[str, str] = {}
+    if not path.exists():
+        return values
+
+    for raw_line in path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key.strip()] = value.strip().strip('"\'')
+    return values
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Create ~/.kaggle/kaggle.json from env vars or a .env file."
+        )
+    )
+    parser.add_argument(
+        "--env-file",
+        default=".env",
+        help=(
+            "Optional .env file to read when environment variables "
+            "are not already set."
+        ),
+    )
+    args = parser.parse_args()
+
+    env_file = Path(args.env_file)
+    env_values = parse_env_file(env_file)
+
+    username = os.environ.get("KAGGLE_USERNAME") or env_values.get(
+        "KAGGLE_USERNAME"
+    )
+    key = os.environ.get("KAGGLE_KEY") or env_values.get(
+        "KAGGLE_KEY"
+    )
+
+    if not username or not key:
+        raise SystemExit(
+            "KAGGLE_USERNAME and KAGGLE_KEY must come from env vars "
+            "or the specified .env file."
+        )
+
+    kaggle_dir = Path.home() / ".kaggle"
+    kaggle_dir.mkdir(parents=True, exist_ok=True)
+    kaggle_json = kaggle_dir / "kaggle.json"
+
+    kaggle_json.write_text(
+        json.dumps({"username": username, "key": key}, indent=2)
+    )
+    os.chmod(kaggle_json, 0o600)
+
+    print(f"Wrote credentials to {kaggle_json} with 0600 permissions.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Implements secure Kaggle integration using GitHub repository secrets only, with no dependency on Azure Key Vault or other external secret systems.

## Changes

- **Security hardening**: Extended `.gitignore` to prevent `kaggle.json`, `.kaggle/`, and `.env.*` from being committed
- **Documentation**: Added `SECURITY.md` with explicit guidance on API key handling
- **CI/CD**: Created `.github/workflows/kaggle-integration.yml` that:
  - Reads `KAGGLE_USERNAME` and `KAGGLE_KEY` from GitHub Secrets
  - Dynamically generates `~/.kaggle/kaggle.json` on the runner
  - Runs a deterministic smoke test (`kaggle datasets list`)
- **Developer docs**: Added `docs/kaggle-integration.md` with:
  - CI workflow explanation
  - Local setup options (both `~/.kaggle/kaggle.json` and `.env` approaches)
  - Security reminders
- **Helper script**: Added `scripts/setup_kaggle_creds.py` to safely materialize Kaggle credentials locally from environment variables or `.env` files

## Testing

- ✅ Verified helper script creates `~/.kaggle/kaggle.json` with correct permissions
- ⏳ Workflow smoke test pending (requires `KAGGLE_USERNAME` and `KAGGLE_KEY` secrets to be configured)

## Checklist

- [x] No credentials or `.env` files committed
- [x] `.gitignore` updated
- [x] Security documentation added
- [x] CI workflow created
- [x] Developer documentation complete