### PR TITLE
feat: parallel processing and quality reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A curated, provenance-tracked dataset of **Elden Ring** game data (base game + S
 - **Fuzzy Text Matching**: DLC text dump integration using Levenshtein distance
 - **PostgreSQL + pgvector**: Ready for semantic search with vector embeddings
 - **Export Formats**: Parquet (partitioned), CSV, and direct Postgres loading
+- **Quality Diagnostics**: HTML/JSON profiling for every curated dataset
 - **Automated Refresh**: GitHub Actions workflow for nightly updates
 
 ## 📊 Data Sources
@@ -72,6 +73,7 @@ elden-botany-corpus/
 │       ├── unified.parquet  # Main output
 │       ├── unified.csv
 │       ├── metadata.json    # Provenance & stats
+│       ├── quality/         # HTML/JSON profiling artifacts
 │       └── unmapped_dlc_text.csv  # Unmatched texts for review
 ├── docker/                  # Docker setup
 │   ├── Dockerfile
@@ -128,7 +130,9 @@ poetry run corpus fetch --all
 poetry run corpus curate
 ```
 
-**Output**: `data/curated/unified.parquet` (~5-10MB) with all entities.
+**Output**: `data/curated/unified.parquet` (~5-10MB) with all entities, plus
+`data/curated/quality/*.json|html` containing per-dataset profiling summaries that
+are referenced inside `data/curated/metadata.json`.
 
 ### 4. (Optional) Load to PostgreSQL
 
@@ -151,7 +155,8 @@ corpus fetch --base --dlc             # Only Kaggle
 corpus fetch --github --impalers      # Fallback + DLC text
 
 # Curate corpus (reconcile + dedupe + export)
-corpus curate
+corpus curate                 # writes reports under data/curated/quality/
+corpus curate --no-quality    # skip HTML/JSON profiling
 
 # Load to PostgreSQL
 corpus load --dsn <POSTGRES_DSN> --create-schema --embed openai

--- a/config/kaggle_datasets.yml
+++ b/config/kaggle_datasets.yml
@@ -36,3 +36,6 @@ settings:
   
   # Whether to unzip downloaded files automatically
   auto_unzip: true
+
+  # Number of worker processes for dataset processing (1 keeps serial)
+  process_workers: 1

--- a/docs/data-processing.md
+++ b/docs/data-processing.md
@@ -144,6 +144,11 @@ Dry run (validate without writing):
 python scripts/process_data.py --dry-run
 ```
 
+Use multiple worker processes (auto CPU detection when 0):
+```bash
+python scripts/process_data.py --workers 4
+```
+
 Custom paths:
 ```bash
 python scripts/process_data.py \
@@ -158,6 +163,30 @@ Save processing statistics:
 python scripts/process_data.py \
   --output-stats processing-stats.json
 ```
+
+### Parallel Execution
+
+Dataset processing now supports optional multiprocessing:
+
+- Pass `--workers N` to `scripts/process_data.py` to process datasets concurrently.
+- Use `--workers 0` to auto-detect CPU count or omit the flag to fall back to the
+  `settings.process_workers` value in `config/kaggle_datasets.yml` (default 1).
+- Serial execution remains the default to preserve deterministic ordering, but
+  multi-core machines see faster rebuilds when opting into concurrency.
+
+### Quality Diagnostics for Curated Data
+
+Running `poetry run corpus curate` now emits lightweight data-profiling reports for
+both the unified dataset and every per-entity export. The curator captures:
+
+- Overall row/column counts and average null percentages.
+- Per-column null percentages, numeric min/max/mean statistics, and the top
+  categorical values (with frequencies) when applicable.
+- HTML and JSON artifacts saved under `data/curated/quality/`, with relative
+  paths recorded in `data/curated/metadata.json` for downstream tooling.
+
+Disable report generation via `corpus curate --no-quality` if you only need the
+raw Parquet/CSV outputs.
 
 ### Change Detection & Dry Runs
 
@@ -399,8 +428,8 @@ poetry run pip install pandera pyarrow
 
 ## Future Enhancements
 
-- [ ] Parallel dataset processing (multiprocessing)
-- [ ] Data quality reports (profiling, stats)
+- [x] Parallel dataset processing (multiprocessing)
+- [x] Data quality reports (profiling, stats)
 - [ ] Schema versioning and migration
 - [ ] Incremental processing for append-only datasets
 - [ ] Data lineage tracking

--- a/pipeline/schemas.py
+++ b/pipeline/schemas.py
@@ -3,11 +3,10 @@
 Uses Pandera for runtime validation and type checking of DataFrames.
 """
 
-from typing import Any, Dict, Optional
+from typing import Any
 
 import pandera as pa
-from pandera import Column, DataFrameSchema, Check
-
+from pandera import Check, Column, DataFrameSchema
 
 # Common field types and validations
 COMMON_CHECKS = {
@@ -42,7 +41,9 @@ ITEMS_SCHEMA = DataFrameSchema(
         ),
         "description": Column(pa.String, nullable=True),
         "weight": Column(pa.Float64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
-        "sell_price": Column(pa.Int64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
+        "sell_price": Column(
+            pa.Int64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True
+        ),
         "max_stack": Column(pa.Int64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
         "rarity": Column(
             pa.String,
@@ -58,9 +59,7 @@ ITEMS_SCHEMA = DataFrameSchema(
 # Elden Ring Weapons Schema
 WEAPONS_SCHEMA = DataFrameSchema(
     {
-        "weapon_id": Column(
-            pa.Int64, nullable=False, unique=True, coerce=True
-        ),
+        "weapon_id": Column(pa.Int64, nullable=False, unique=True, coerce=True),
         "name": Column(
             pa.String,
             nullable=False,
@@ -124,18 +123,42 @@ ARMOR_SCHEMA = DataFrameSchema(
             checks=Check.isin(["head", "chest", "arms", "legs"]),
         ),
         "weight": Column(pa.Float64, nullable=False, checks=COMMON_CHECKS["positive"], coerce=True),
-        "defense_physical": Column(pa.Float64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
-        "defense_strike": Column(pa.Float64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
-        "defense_slash": Column(pa.Float64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
-        "defense_pierce": Column(pa.Float64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
-        "defense_magic": Column(pa.Float64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
-        "defense_fire": Column(pa.Float64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
-        "defense_lightning": Column(pa.Float64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
-        "defense_holy": Column(pa.Float64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
-        "resistance_immunity": Column(pa.Int64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
-        "resistance_robustness": Column(pa.Int64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
-        "resistance_focus": Column(pa.Int64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
-        "resistance_vitality": Column(pa.Int64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
+        "defense_physical": Column(
+            pa.Float64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True
+        ),
+        "defense_strike": Column(
+            pa.Float64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True
+        ),
+        "defense_slash": Column(
+            pa.Float64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True
+        ),
+        "defense_pierce": Column(
+            pa.Float64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True
+        ),
+        "defense_magic": Column(
+            pa.Float64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True
+        ),
+        "defense_fire": Column(
+            pa.Float64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True
+        ),
+        "defense_lightning": Column(
+            pa.Float64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True
+        ),
+        "defense_holy": Column(
+            pa.Float64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True
+        ),
+        "resistance_immunity": Column(
+            pa.Int64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True
+        ),
+        "resistance_robustness": Column(
+            pa.Int64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True
+        ),
+        "resistance_focus": Column(
+            pa.Int64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True
+        ),
+        "resistance_vitality": Column(
+            pa.Int64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True
+        ),
         "poise": Column(pa.Float64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
     },
     strict=False,
@@ -154,11 +177,21 @@ SPELLS_SCHEMA = DataFrameSchema(
             checks=Check.isin(["sorcery", "incantation"]),
         ),
         "fp_cost": Column(pa.Int64, nullable=False, checks=COMMON_CHECKS["positive"], coerce=True),
-        "stamina_cost": Column(pa.Int64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
-        "slots_required": Column(pa.Int64, nullable=False, checks=COMMON_CHECKS["positive"], coerce=True),
-        "required_int": Column(pa.Int64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
-        "required_fai": Column(pa.Int64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
-        "required_arc": Column(pa.Int64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
+        "stamina_cost": Column(
+            pa.Int64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True
+        ),
+        "slots_required": Column(
+            pa.Int64, nullable=False, checks=COMMON_CHECKS["positive"], coerce=True
+        ),
+        "required_int": Column(
+            pa.Int64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True
+        ),
+        "required_fai": Column(
+            pa.Int64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True
+        ),
+        "required_arc": Column(
+            pa.Int64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True
+        ),
         "description": Column(pa.String, nullable=True),
     },
     strict=False,
@@ -167,7 +200,7 @@ SPELLS_SCHEMA = DataFrameSchema(
 
 
 # Schema registry
-SCHEMA_REGISTRY: Dict[str, DataFrameSchema] = {
+SCHEMA_REGISTRY: dict[str, DataFrameSchema] = {
     "items": ITEMS_SCHEMA,
     "weapons": WEAPONS_SCHEMA,
     "bosses": BOSSES_SCHEMA,
@@ -176,7 +209,7 @@ SCHEMA_REGISTRY: Dict[str, DataFrameSchema] = {
 }
 
 
-def get_dataset_schema(dataset_name: str) -> Optional[DataFrameSchema]:
+def get_dataset_schema(dataset_name: str) -> DataFrameSchema | None:
     """Get the Pandera schema for a dataset by name.
 
     Args:
@@ -187,22 +220,23 @@ def get_dataset_schema(dataset_name: str) -> Optional[DataFrameSchema]:
     """
     # Normalize dataset name
     normalized = dataset_name.lower().replace("-", "_").replace(" ", "_")
-    
+
     # Try exact match first
     if normalized in SCHEMA_REGISTRY:
         return SCHEMA_REGISTRY[normalized]
-    
+
     # Try fuzzy match (contains)
     for key, schema in SCHEMA_REGISTRY.items():
         if key in normalized or normalized in key:
             return schema
-    
+
     return None
 
 
 def validate_dataframe(
-    df, schema: DataFrameSchema
-) -> tuple[bool, Optional[str], Any]:
+    df,
+    schema: DataFrameSchema,
+) -> tuple[bool, str | None, Any]:
     """Validate a DataFrame against a schema.
 
     Args:

--- a/pipeline/utils.py
+++ b/pipeline/utils.py
@@ -10,7 +10,7 @@ Provides helper functions for:
 import hashlib
 import json
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any
 
 import pandas as pd
 
@@ -39,9 +39,7 @@ def normalize_column_names(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def handle_missing_values(
-    df: pd.DataFrame, strategy: Dict[str, Any]
-) -> pd.DataFrame:
+def handle_missing_values(df: pd.DataFrame, strategy: dict[str, Any]) -> pd.DataFrame:
     """Handle missing values based on column-specific strategies.
 
     Args:
@@ -76,9 +74,7 @@ def handle_missing_values(
     return df
 
 
-def normalize_categorical(
-    df: pd.DataFrame, mappings: Dict[str, Dict[str, str]]
-) -> pd.DataFrame:
+def normalize_categorical(df: pd.DataFrame, mappings: dict[str, dict[str, str]]) -> pd.DataFrame:
     """Normalize categorical values using predefined mappings.
 
     Args:
@@ -99,7 +95,7 @@ def normalize_categorical(
     return df
 
 
-def coerce_types(df: pd.DataFrame, type_map: Dict[str, str]) -> pd.DataFrame:
+def coerce_types(df: pd.DataFrame, type_map: dict[str, str]) -> pd.DataFrame:
     """Coerce DataFrame columns to specified types.
 
     Args:
@@ -118,9 +114,7 @@ def coerce_types(df: pd.DataFrame, type_map: Dict[str, str]) -> pd.DataFrame:
 
         try:
             if target_type == "int":
-                df[col] = pd.to_numeric(df[col], errors="coerce").astype(
-                    "Int64"
-                )
+                df[col] = pd.to_numeric(df[col], errors="coerce").astype("Int64")
             elif target_type == "float":
                 df[col] = pd.to_numeric(df[col], errors="coerce")
             elif target_type == "bool":
@@ -153,7 +147,9 @@ def calculate_file_hash(filepath: Path) -> str:
 
 
 def needs_processing(
-    raw_path: Path, processed_path: Path, cache_file: Optional[Path] = None
+    raw_path: Path,
+    processed_path: Path,
+    cache_file: Path | None = None,
 ) -> bool:
     """Check if raw file needs to be processed.
 
@@ -174,7 +170,7 @@ def needs_processing(
     if not processed_path.exists():
         return True
 
-    cached_hash: Optional[str] = None
+    cached_hash: str | None = None
     if cache_file and cache_file.exists():
         try:
             with open(cache_file) as f:
@@ -234,7 +230,7 @@ def detect_delimiter(filepath: Path, sample_size: int = 10) -> str:
     counts = {d: sample.count(d) for d in delimiters}
 
     # Return delimiter with highest count
-    return max(counts, key=counts.get)
+    return max(counts, key=lambda delimiter: counts[delimiter])
 
 
 def read_data_file(filepath: Path) -> pd.DataFrame:
@@ -262,9 +258,7 @@ def read_data_file(filepath: Path) -> pd.DataFrame:
         raise ValueError(f"Unsupported file format: {suffix}")
 
 
-def write_parquet(
-    df: pd.DataFrame, output_path: Path, compression: str = "snappy"
-):
+def write_parquet(df: pd.DataFrame, output_path: Path, compression: str = "snappy"):
     """Write DataFrame to Parquet with consistent settings.
 
     Args:
@@ -273,12 +267,10 @@ def write_parquet(
         compression: Compression algorithm ('snappy', 'gzip', 'brotli')
     """
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    df.to_parquet(
-        output_path, compression=compression, index=False, engine="pyarrow"
-    )
+    df.to_parquet(output_path, compression=compression, index=False, engine="pyarrow")
 
 
-def get_processing_stats(df: pd.DataFrame) -> Dict[str, Any]:
+def get_processing_stats(df: pd.DataFrame) -> dict[str, Any]:
     """Generate processing statistics for a DataFrame.
 
     Args:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -27,6 +27,25 @@ python -m scripts.download_kaggle_dataset \
 
 ---
 
+### `process_data.py`
+
+Processes raw datasets into validated Parquet outputs with optional concurrency.
+
+**Usage:**
+```bash
+python scripts/process_data.py [--force] [--dry-run] [--workers N]
+```
+
+**Highlights:**
+- Detects stale datasets before processing and supports dry-run validation.
+- `--workers N` (or config `settings.process_workers`) parallelizes dataset
+  work; use `--workers 0` to auto-detect CPU count or omit for serial mode.
+- Supports writing processing statistics via `--output-stats path.json`.
+
+Refer to `docs/data-processing.md` for the full pipeline guide.
+
+---
+
 ### `setup_kaggle_creds.py`
 
 Generates `~/.kaggle/kaggle.json` from environment variables.

--- a/scripts/process_data.py
+++ b/scripts/process_data.py
@@ -102,6 +102,16 @@ Examples:
         help="Write processing statistics to JSON file",
     )
 
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=None,
+        help=(
+            "Number of worker processes to use (default: serial or value "
+            "from config settings). Use 0 to auto-detect CPU count."
+        ),
+    )
+
     args = parser.parse_args()
 
     # Setup logging
@@ -126,6 +136,10 @@ Examples:
     logger.info(f"Processed directory: {args.processed_dir}")
     logger.info(f"Force reprocess: {args.force}")
     logger.info(f"Dry run: {args.dry_run}")
+    logger.info(
+        "Workers: %s",
+        "auto" if args.workers == 0 else args.workers or "config",
+    )
     logger.info("=" * 60)
 
     # Create processor
@@ -153,7 +167,11 @@ Examples:
 
     # Process all datasets
     try:
-        results = processor.process_all(force=args.force, dry_run=args.dry_run)
+        results = processor.process_all(
+            force=args.force,
+            dry_run=args.dry_run,
+            workers=args.workers,
+        )
 
         # Print summary
         logger.info("=" * 60)

--- a/src/corpus/cli.py
+++ b/src/corpus/cli.py
@@ -91,13 +91,21 @@ def fetch(
 
 
 @main.command()
-def curate() -> None:
+@click.option(
+    "--quality/--no-quality",
+    default=True,
+    help="Generate HTML/JSON quality reports for curated datasets",
+)
+def curate(quality: bool) -> None:
     """Reconcile and curate corpus data."""
     try:
         # Re-fetch (should use cached data)
         click.echo("Loading cached data...")
 
-        kaggle_entities = fetch_kaggle_data(include_base=True, include_dlc=True)
+        kaggle_entities = fetch_kaggle_data(
+            include_base=True,
+            include_dlc=True,
+        )
         kaggle_base = [e for e in kaggle_entities if not e.is_dlc]
         kaggle_dlc = [e for e in kaggle_entities if e.is_dlc]
 
@@ -113,7 +121,11 @@ def curate() -> None:
         )
 
         # Curate and export
-        df = curate_corpus(entities, unmapped)
+        df = curate_corpus(
+            entities,
+            unmapped,
+            enable_quality_reports=quality,
+        )
 
         click.echo(f"\n✓ Curated {len(df)} entities")
         click.echo(f"  Output: {settings.curated_dir / 'unified.parquet'}")
@@ -168,7 +180,10 @@ def load(
             # Temporarily override settings
             original_provider = settings.embed_provider
             # Cast is safe because click.Choice validates the input
-            settings.embed_provider = cast(Literal["openai", "local", "none"], embed)
+            settings.embed_provider = cast(
+                Literal["openai", "local", "none"],
+                embed,
+            )
 
         load_to_postgres(
             dsn=dsn,

--- a/src/corpus/quality.py
+++ b/src/corpus/quality.py
@@ -1,0 +1,257 @@
+"""Utilities for generating quality reports for curated datasets."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from html import escape
+from pathlib import Path
+from typing import Any
+
+import polars as pl  # type: ignore[import]
+
+from corpus.utils import save_json
+
+
+class QualityReporter:
+    """Build JSON + HTML quality reports for Polars DataFrames."""
+
+    def __init__(
+        self,
+        output_dir: Path,
+        relative_root: Path | None = None,
+    ) -> None:
+        """Create a reporter that writes reports to ``output_dir``.
+
+        Args:
+            output_dir: Directory where report artifacts are stored.
+            relative_root: Base path used for computing metadata-friendly
+                relative paths. Defaults to ``output_dir.parent``.
+        """
+
+        self.output_dir = output_dir
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.relative_root = relative_root or output_dir.parent
+
+    def generate_report(
+        self,
+        dataset_name: str,
+        df: pl.DataFrame,
+    ) -> dict[str, Any]:
+        """Profile a DataFrame and emit JSON + HTML reports.
+
+        Args:
+            dataset_name: Logical dataset name (e.g., ``"unified"`` or
+                ``"weapon"``).
+            df: Curated Polars DataFrame to profile.
+
+        Returns:
+            Summary metadata describing the generated reports.
+        """
+
+        safe_name = self._safe_name(dataset_name)
+        json_path = self.output_dir / f"{safe_name}.json"
+        html_path = self.output_dir / f"{safe_name}.html"
+
+        profile = self._build_profile(dataset_name, df)
+        save_json(profile, json_path, indent=2)
+        html_path.write_text(self._render_html(profile), encoding="utf-8")
+
+        return {
+            "dataset": dataset_name,
+            "rows": profile["row_count"],
+            "columns": profile["column_count"],
+            "null_pct_avg": profile["summary"]["avg_null_percentage"],
+            "json_report": str(json_path.relative_to(self.relative_root)),
+            "html_report": str(html_path.relative_to(self.relative_root)),
+        }
+
+    def _build_profile(
+        self,
+        dataset_name: str,
+        df: pl.DataFrame,
+    ) -> dict[str, Any]:
+        """Compute column-level statistics for the provided DataFrame."""
+
+        row_count = df.height
+        columns: list[dict[str, Any]] = []
+        total_null_pct = 0.0
+
+        for column in df.columns:
+            series = df[column]
+            null_count = series.null_count()
+            null_pct = round(
+                (null_count / row_count * 100) if row_count else 0.0,
+                2,
+            )
+            total_null_pct += null_pct
+
+            column_profile: dict[str, Any] = {
+                "name": column,
+                "dtype": str(series.dtype),
+                "null_count": int(null_count),
+                "null_percentage": null_pct,
+            }
+
+            if self._is_numeric(series.dtype):
+                stats = self._numeric_stats(series)
+                if stats:
+                    column_profile["stats"] = stats
+            elif self._is_categorical(series):
+                top_categories = self._top_categories(
+                    series,
+                    row_count - null_count,
+                )
+                if top_categories:
+                    column_profile["top_categories"] = top_categories
+
+            columns.append(column_profile)
+
+        avg_null_pct = (
+            round(
+                total_null_pct / len(df.columns),
+                2,
+            )
+            if df.columns
+            else 0.0
+        )
+
+        return {
+            "dataset": dataset_name,
+            "generated_at": datetime.now(UTC).isoformat(),
+            "row_count": row_count,
+            "column_count": len(df.columns),
+            "summary": {
+                "avg_null_percentage": avg_null_pct,
+            },
+            "columns": columns,
+        }
+
+    @staticmethod
+    def _numeric_stats(series: pl.Series) -> dict[str, float] | None:
+        """Return min/max/mean statistics for numeric columns."""
+
+        numeric = series.drop_nulls()
+        if numeric.is_empty():
+            return None
+
+        return {
+            "min": float(numeric.min()),
+            "max": float(numeric.max()),
+            "mean": float(numeric.mean()),
+        }
+
+    @staticmethod
+    def _is_numeric(dtype: pl.DataType) -> bool:
+        """Heuristic numeric detection for various Polars dtypes."""
+
+        dtype_name = dtype.__class__.__name__.lower()
+        return dtype_name.startswith(("int", "uint", "float", "decimal"))
+
+    @staticmethod
+    def _is_categorical(series: pl.Series) -> bool:
+        """Heuristic check for categorical/text columns."""
+
+        return series.dtype in {pl.Utf8, pl.Categorical, pl.Boolean}
+
+    @staticmethod
+    def _top_categories(
+        series: pl.Series,
+        non_null_rows: int,
+        limit: int = 5,
+    ) -> list[dict[str, Any]]:
+        """Return value counts for string-like columns."""
+
+        if non_null_rows <= 0:
+            return []
+
+        value_counts = (
+            series.drop_nulls().value_counts().sort("counts", descending=True).head(limit)
+        )
+        value_column = value_counts.columns[0] if value_counts.columns else "value"
+
+        top_values: list[dict[str, Any]] = []
+        for row in value_counts.iter_rows(named=True):
+            count = int(row["counts"])
+            pct = round((count / non_null_rows) * 100, 2)
+            top_values.append(
+                {
+                    "value": row[value_column],
+                    "count": count,
+                    "percentage": pct,
+                }
+            )
+        return top_values
+
+    @staticmethod
+    def _safe_name(dataset_name: str) -> str:
+        """Create filesystem-friendly file names for datasets."""
+
+        return dataset_name.lower().replace(" ", "_")
+
+    @staticmethod
+    def _render_html(profile: dict[str, Any]) -> str:
+        """Render a lightweight HTML summary of the quality report."""
+
+        head = (
+            "<!DOCTYPE html>\n"
+            '<html lang="en">\n'
+            "<head>\n"
+            '  <meta charset="utf-8" />\n'
+            "  <title>Quality Report - {title}</title>\n"
+            "  <style>\n"
+            "    body {{ font-family: Arial, sans-serif; padding: 1.5rem; }}\n"
+            "    table {{ border-collapse: collapse; width: 100%;"
+            " margin-top: 1rem; }}\n"
+            "    th, td {{ border: 1px solid #ddd; padding: 0.5rem;"
+            " text-align: left; }}\n"
+            "    th {{ background-color: #f4f4f4; }}\n"
+            "  </style>\n"
+            "</head>\n"
+        ).format(title=escape(str(profile["dataset"])))
+
+        header_section = (
+            "<body>\n"
+            f"  <h1>Quality Report: {escape(str(profile['dataset']))}</h1>\n"
+            f"  <p>Generated at: {escape(str(profile['generated_at']))}</p>\n"
+            f"  <p>Rows: {profile['row_count']} • Columns:"
+            f" {profile['column_count']} • Avg. null %:"
+            f" {profile['summary']['avg_null_percentage']}%</p>\n"
+        )
+
+        table_rows = []
+        for column in profile["columns"]:
+            stats_html = ""
+            if "stats" in column:
+                stats = column["stats"]
+                stats_html = (
+                    f"min={stats['min']:.2f}, max={stats['max']:.2f}, " f"mean={stats['mean']:.2f}"
+                )
+            elif "top_categories" in column:
+                cats = ", ".join(
+                    f"{escape(str(item['value']))} ({item['percentage']}%)"
+                    for item in column["top_categories"]
+                )
+                stats_html = cats
+
+            table_rows.append(
+                "    <tr>\n"
+                f"      <td>{escape(column['name'])}</td>\n"
+                f"      <td>{escape(column['dtype'])}</td>\n"
+                f"      <td>{column['null_percentage']}%</td>\n"
+                f"      <td>{escape(stats_html) if stats_html else '-'}</td>\n"
+                "    </tr>\n"
+            )
+
+        table_html = (
+            "  <table>\n"
+            "    <thead>\n"
+            "      <tr><th>Column</th><th>Type</th><th>Null %</th>"
+            "<th>Details</th></tr>\n"
+            "    </thead>\n"
+            "    <tbody>\n"
+            f"{''.join(table_rows)}"
+            "    </tbody>\n"
+            "  </table>\n"
+        )
+
+        return head + header_section + table_html + "</body>\n</html>\n"

--- a/src/corpus/utils.py
+++ b/src/corpus/utils.py
@@ -126,6 +126,7 @@ class MetadataTracker:
             "duplicates_removed": {},
             "unmapped_texts": 0,
             "provenance_summary": {},
+            "quality_reports": {},
         }
 
     def add_row_count(self, source: str, count: int) -> None:
@@ -151,6 +152,15 @@ class MetadataTracker:
     def add_provenance_summary(self, source: str, count: int) -> None:
         """Add provenance summary."""
         self.metadata["provenance_summary"][source] = count
+
+    def add_quality_report(
+        self,
+        dataset: str,
+        summary: dict[str, Any],
+    ) -> None:
+        """Register quality report artifact metadata."""
+
+        self.metadata["quality_reports"][dataset] = summary
 
     def save(self, file_path: Path) -> None:
         """Save metadata to JSON."""

--- a/tests/test_quality_reports.py
+++ b/tests/test_quality_reports.py
@@ -1,0 +1,84 @@
+"""Tests for automated quality report generation."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+corpus_curate = importlib.import_module("corpus.curate")
+corpus_quality = importlib.import_module("corpus.quality")
+
+pl = pytest.importorskip("polars")
+CorpusCurator = corpus_curate.CorpusCurator
+QualityReporter = corpus_quality.QualityReporter
+
+
+def test_quality_reporter_generates_profiles(tmp_path: Path) -> None:
+    """QualityReporter should emit JSON + HTML artifacts with stats."""
+
+    df = pl.DataFrame(
+        {
+            "name": ["Sword", "Shield", None],
+            "rarity": ["common", "rare", "rare"],
+            "weight": [8.5, 12.0, None],
+        }
+    )
+
+    reporter = QualityReporter(
+        output_dir=tmp_path / "quality",
+        relative_root=tmp_path,
+    )
+    summary = reporter.generate_report("unified", df)
+
+    json_path = tmp_path / summary["json_report"]
+    html_path = tmp_path / summary["html_report"]
+
+    assert json_path.exists()
+    assert html_path.exists()
+
+    payload = json.loads(json_path.read_text())
+    assert payload["row_count"] == 3
+    assert payload["column_count"] == 3
+    assert any(col["name"] == "rarity" for col in payload["columns"])
+
+
+def test_curator_records_quality_reports(tmp_path: Path) -> None:
+    """CorpusCurator should capture report metadata for all exports."""
+
+    curated_dir = tmp_path / "curated"
+    curator = CorpusCurator(
+        output_dir=curated_dir,
+        enable_quality_reports=True,
+    )
+
+    df = pl.DataFrame(
+        {
+            "entity_type": ["weapon", "weapon", "boss"],
+            "name": ["Sword", "Axe", "Margit"],
+            "meta_json": [{"tier": 1}, {"tier": 2}, {"tier": 5}],
+            "sources": [["kaggle"], ["github"], ["kaggle"]],
+        }
+    )
+
+    curator.export_unified(df)
+    curator.export_by_entity_type(df)
+
+    reports = curator.metadata.metadata["quality_reports"]
+    assert set(reports) == {"unified", "weapon", "boss"}
+
+    unified_report = reports["unified"]
+    assert unified_report["rows"] == 3
+    assert unified_report["json_report"].startswith("quality/")
+
+    report_path = curated_dir / unified_report["json_report"]
+    assert report_path.exists()
+    assert json.loads(report_path.read_text())["dataset"] == "unified"


### PR DESCRIPTION
## Summary
- add worker pool support across the pipeline, CLI, and scripts so large corpora process faster with a `--workers` flag
- capture dataset quality reports via the new `corpus.quality` module and surface their metadata after each run
- document the new workflow, configuration, and tests validating the multiprocessing path and quality report export

## Testing
- `poetry run ruff check --fix .`
- `poetry run ruff format .`
- `poetry run pytest`
