### PR TITLE
feat: automated curated quality reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A curated, provenance-tracked dataset of **Elden Ring** game data (base game + S
 - **Fuzzy Text Matching**: DLC text dump integration using Levenshtein distance
 - **PostgreSQL + pgvector**: Ready for semantic search with vector embeddings
 - **Export Formats**: Parquet (partitioned), CSV, and direct Postgres loading
+- **Quality Reports**: JSON + HTML profiling emitted for every curated dataset
 - **Automated Refresh**: GitHub Actions workflow for nightly updates
 
 ## 📊 Data Sources
@@ -72,6 +73,7 @@ elden-botany-corpus/
 │       ├── unified.parquet  # Main output
 │       ├── unified.csv
 │       ├── metadata.json    # Provenance & stats
+│       ├── quality/         # HTML + JSON profiling per dataset
 │       └── unmapped_dlc_text.csv  # Unmatched texts for review
 ├── docker/                  # Docker setup
 │   ├── Dockerfile
@@ -128,7 +130,7 @@ poetry run corpus fetch --all
 poetry run corpus curate
 ```
 
-**Output**: `data/curated/unified.parquet` (~5-10MB) with all entities.
+**Output**: `data/curated/unified.parquet` (~5-10MB) with all entities. Quality diagnostics are co-located under `data/curated/quality/` and summarized in `data/curated/metadata.json`.
 
 ### 4. (Optional) Load to PostgreSQL
 
@@ -371,6 +373,13 @@ poetry run corpus fetch --all
 ```
 
 ## 📊 Data Quality
+
+### Automated Quality Reports
+
+- Each `corpus curate` run now emits JSON + HTML profiles under `data/curated/quality/` (one per unified + entity dataset).
+- Reports capture row counts, column-level null percentages, numeric min/max/mean/std, categorical top values, and a curated list of `alerts` for quick triage.
+- `data/curated/metadata.json` stores the same payload under `quality_reports`, so CI or downstream jobs can fail fast if an alert is present (e.g., `null_percent >= 50%`).
+- To enforce thresholds, parse the metadata file inside your automation and exit non-zero if any alert matches your rule set.
 
 ### Reconciliation Logic
 

--- a/pipeline/schemas.py
+++ b/pipeline/schemas.py
@@ -3,11 +3,10 @@
 Uses Pandera for runtime validation and type checking of DataFrames.
 """
 
-from typing import Any, Dict, Optional
+from typing import Any
 
 import pandera as pa
-from pandera import Column, DataFrameSchema, Check
-
+from pandera import Check, Column, DataFrameSchema
 
 # Common field types and validations
 COMMON_CHECKS = {
@@ -21,7 +20,11 @@ COMMON_CHECKS = {
 ITEMS_SCHEMA = DataFrameSchema(
     {
         "item_id": Column(pa.Int64, nullable=False, unique=True, coerce=True),
-        "name": Column(pa.String, nullable=False, checks=COMMON_CHECKS["non_empty_str"]),
+        "name": Column(
+            pa.String,
+            nullable=False,
+            checks=COMMON_CHECKS["non_empty_str"],
+        ),
         "category": Column(
             pa.String,
             nullable=False,
@@ -41,9 +44,24 @@ ITEMS_SCHEMA = DataFrameSchema(
             ),
         ),
         "description": Column(pa.String, nullable=True),
-        "weight": Column(pa.Float64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
-        "sell_price": Column(pa.Int64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
-        "max_stack": Column(pa.Int64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
+        "weight": Column(
+            pa.Float64,
+            nullable=True,
+            checks=COMMON_CHECKS["positive"],
+            coerce=True,
+        ),
+        "sell_price": Column(
+            pa.Int64,
+            nullable=True,
+            checks=COMMON_CHECKS["positive"],
+            coerce=True,
+        ),
+        "max_stack": Column(
+            pa.Int64,
+            nullable=True,
+            checks=COMMON_CHECKS["positive"],
+            coerce=True,
+        ),
         "rarity": Column(
             pa.String,
             nullable=True,
@@ -58,9 +76,7 @@ ITEMS_SCHEMA = DataFrameSchema(
 # Elden Ring Weapons Schema
 WEAPONS_SCHEMA = DataFrameSchema(
     {
-        "weapon_id": Column(
-            pa.Int64, nullable=False, unique=True, coerce=True
-        ),
+        "weapon_id": Column(pa.Int64, nullable=False, unique=True, coerce=True),
         "name": Column(
             pa.String,
             nullable=False,
@@ -116,27 +132,106 @@ BOSSES_SCHEMA = DataFrameSchema(
 # Armor Schema
 ARMOR_SCHEMA = DataFrameSchema(
     {
-        "armor_id": Column(pa.Int64, nullable=False, unique=True, coerce=True),
-        "name": Column(pa.String, nullable=False, checks=COMMON_CHECKS["non_empty_str"]),
+        "armor_id": Column(
+            pa.Int64,
+            nullable=False,
+            unique=True,
+            coerce=True,
+        ),
+        "name": Column(
+            pa.String,
+            nullable=False,
+            checks=COMMON_CHECKS["non_empty_str"],
+        ),
         "armor_type": Column(
             pa.String,
             nullable=False,
             checks=Check.isin(["head", "chest", "arms", "legs"]),
         ),
-        "weight": Column(pa.Float64, nullable=False, checks=COMMON_CHECKS["positive"], coerce=True),
-        "defense_physical": Column(pa.Float64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
-        "defense_strike": Column(pa.Float64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
-        "defense_slash": Column(pa.Float64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
-        "defense_pierce": Column(pa.Float64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
-        "defense_magic": Column(pa.Float64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
-        "defense_fire": Column(pa.Float64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
-        "defense_lightning": Column(pa.Float64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
-        "defense_holy": Column(pa.Float64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
-        "resistance_immunity": Column(pa.Int64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
-        "resistance_robustness": Column(pa.Int64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
-        "resistance_focus": Column(pa.Int64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
-        "resistance_vitality": Column(pa.Int64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
-        "poise": Column(pa.Float64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
+        "weight": Column(
+            pa.Float64,
+            nullable=False,
+            checks=COMMON_CHECKS["positive"],
+            coerce=True,
+        ),
+        "defense_physical": Column(
+            pa.Float64,
+            nullable=True,
+            checks=COMMON_CHECKS["positive"],
+            coerce=True,
+        ),
+        "defense_strike": Column(
+            pa.Float64,
+            nullable=True,
+            checks=COMMON_CHECKS["positive"],
+            coerce=True,
+        ),
+        "defense_slash": Column(
+            pa.Float64,
+            nullable=True,
+            checks=COMMON_CHECKS["positive"],
+            coerce=True,
+        ),
+        "defense_pierce": Column(
+            pa.Float64,
+            nullable=True,
+            checks=COMMON_CHECKS["positive"],
+            coerce=True,
+        ),
+        "defense_magic": Column(
+            pa.Float64,
+            nullable=True,
+            checks=COMMON_CHECKS["positive"],
+            coerce=True,
+        ),
+        "defense_fire": Column(
+            pa.Float64,
+            nullable=True,
+            checks=COMMON_CHECKS["positive"],
+            coerce=True,
+        ),
+        "defense_lightning": Column(
+            pa.Float64,
+            nullable=True,
+            checks=COMMON_CHECKS["positive"],
+            coerce=True,
+        ),
+        "defense_holy": Column(
+            pa.Float64,
+            nullable=True,
+            checks=COMMON_CHECKS["positive"],
+            coerce=True,
+        ),
+        "resistance_immunity": Column(
+            pa.Int64,
+            nullable=True,
+            checks=COMMON_CHECKS["positive"],
+            coerce=True,
+        ),
+        "resistance_robustness": Column(
+            pa.Int64,
+            nullable=True,
+            checks=COMMON_CHECKS["positive"],
+            coerce=True,
+        ),
+        "resistance_focus": Column(
+            pa.Int64,
+            nullable=True,
+            checks=COMMON_CHECKS["positive"],
+            coerce=True,
+        ),
+        "resistance_vitality": Column(
+            pa.Int64,
+            nullable=True,
+            checks=COMMON_CHECKS["positive"],
+            coerce=True,
+        ),
+        "poise": Column(
+            pa.Float64,
+            nullable=True,
+            checks=COMMON_CHECKS["positive"],
+            coerce=True,
+        ),
     },
     strict=False,
     coerce=True,
@@ -146,19 +241,58 @@ ARMOR_SCHEMA = DataFrameSchema(
 # Spells Schema
 SPELLS_SCHEMA = DataFrameSchema(
     {
-        "spell_id": Column(pa.Int64, nullable=False, unique=True, coerce=True),
-        "name": Column(pa.String, nullable=False, checks=COMMON_CHECKS["non_empty_str"]),
+        "spell_id": Column(
+            pa.Int64,
+            nullable=False,
+            unique=True,
+            coerce=True,
+        ),
+        "name": Column(
+            pa.String,
+            nullable=False,
+            checks=COMMON_CHECKS["non_empty_str"],
+        ),
         "spell_type": Column(
             pa.String,
             nullable=False,
             checks=Check.isin(["sorcery", "incantation"]),
         ),
-        "fp_cost": Column(pa.Int64, nullable=False, checks=COMMON_CHECKS["positive"], coerce=True),
-        "stamina_cost": Column(pa.Int64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
-        "slots_required": Column(pa.Int64, nullable=False, checks=COMMON_CHECKS["positive"], coerce=True),
-        "required_int": Column(pa.Int64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
-        "required_fai": Column(pa.Int64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
-        "required_arc": Column(pa.Int64, nullable=True, checks=COMMON_CHECKS["positive"], coerce=True),
+        "fp_cost": Column(
+            pa.Int64,
+            nullable=False,
+            checks=COMMON_CHECKS["positive"],
+            coerce=True,
+        ),
+        "stamina_cost": Column(
+            pa.Int64,
+            nullable=True,
+            checks=COMMON_CHECKS["positive"],
+            coerce=True,
+        ),
+        "slots_required": Column(
+            pa.Int64,
+            nullable=False,
+            checks=COMMON_CHECKS["positive"],
+            coerce=True,
+        ),
+        "required_int": Column(
+            pa.Int64,
+            nullable=True,
+            checks=COMMON_CHECKS["positive"],
+            coerce=True,
+        ),
+        "required_fai": Column(
+            pa.Int64,
+            nullable=True,
+            checks=COMMON_CHECKS["positive"],
+            coerce=True,
+        ),
+        "required_arc": Column(
+            pa.Int64,
+            nullable=True,
+            checks=COMMON_CHECKS["positive"],
+            coerce=True,
+        ),
         "description": Column(pa.String, nullable=True),
     },
     strict=False,
@@ -167,7 +301,7 @@ SPELLS_SCHEMA = DataFrameSchema(
 
 
 # Schema registry
-SCHEMA_REGISTRY: Dict[str, DataFrameSchema] = {
+SCHEMA_REGISTRY: dict[str, DataFrameSchema] = {
     "items": ITEMS_SCHEMA,
     "weapons": WEAPONS_SCHEMA,
     "bosses": BOSSES_SCHEMA,
@@ -176,7 +310,7 @@ SCHEMA_REGISTRY: Dict[str, DataFrameSchema] = {
 }
 
 
-def get_dataset_schema(dataset_name: str) -> Optional[DataFrameSchema]:
+def get_dataset_schema(dataset_name: str) -> DataFrameSchema | None:
     """Get the Pandera schema for a dataset by name.
 
     Args:
@@ -187,22 +321,20 @@ def get_dataset_schema(dataset_name: str) -> Optional[DataFrameSchema]:
     """
     # Normalize dataset name
     normalized = dataset_name.lower().replace("-", "_").replace(" ", "_")
-    
+
     # Try exact match first
     if normalized in SCHEMA_REGISTRY:
         return SCHEMA_REGISTRY[normalized]
-    
+
     # Try fuzzy match (contains)
     for key, schema in SCHEMA_REGISTRY.items():
         if key in normalized or normalized in key:
             return schema
-    
+
     return None
 
 
-def validate_dataframe(
-    df, schema: DataFrameSchema
-) -> tuple[bool, Optional[str], Any]:
+def validate_dataframe(df, schema: DataFrameSchema) -> tuple[bool, str | None, Any]:
     """Validate a DataFrame against a schema.
 
     Args:

--- a/pipeline/utils.py
+++ b/pipeline/utils.py
@@ -10,7 +10,7 @@ Provides helper functions for:
 import hashlib
 import json
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any
 
 import pandas as pd
 
@@ -39,9 +39,7 @@ def normalize_column_names(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def handle_missing_values(
-    df: pd.DataFrame, strategy: Dict[str, Any]
-) -> pd.DataFrame:
+def handle_missing_values(df: pd.DataFrame, strategy: dict[str, Any]) -> pd.DataFrame:
     """Handle missing values based on column-specific strategies.
 
     Args:
@@ -76,9 +74,7 @@ def handle_missing_values(
     return df
 
 
-def normalize_categorical(
-    df: pd.DataFrame, mappings: Dict[str, Dict[str, str]]
-) -> pd.DataFrame:
+def normalize_categorical(df: pd.DataFrame, mappings: dict[str, dict[str, str]]) -> pd.DataFrame:
     """Normalize categorical values using predefined mappings.
 
     Args:
@@ -99,7 +95,7 @@ def normalize_categorical(
     return df
 
 
-def coerce_types(df: pd.DataFrame, type_map: Dict[str, str]) -> pd.DataFrame:
+def coerce_types(df: pd.DataFrame, type_map: dict[str, str]) -> pd.DataFrame:
     """Coerce DataFrame columns to specified types.
 
     Args:
@@ -118,9 +114,7 @@ def coerce_types(df: pd.DataFrame, type_map: Dict[str, str]) -> pd.DataFrame:
 
         try:
             if target_type == "int":
-                df[col] = pd.to_numeric(df[col], errors="coerce").astype(
-                    "Int64"
-                )
+                df[col] = pd.to_numeric(df[col], errors="coerce").astype("Int64")
             elif target_type == "float":
                 df[col] = pd.to_numeric(df[col], errors="coerce")
             elif target_type == "bool":
@@ -152,9 +146,7 @@ def calculate_file_hash(filepath: Path) -> str:
     return sha256.hexdigest()
 
 
-def needs_processing(
-    raw_path: Path, processed_path: Path, cache_file: Optional[Path] = None
-) -> bool:
+def needs_processing(raw_path: Path, processed_path: Path, cache_file: Path | None = None) -> bool:
     """Check if raw file needs to be processed.
 
     Compares:
@@ -174,7 +166,7 @@ def needs_processing(
     if not processed_path.exists():
         return True
 
-    cached_hash: Optional[str] = None
+    cached_hash: str | None = None
     if cache_file and cache_file.exists():
         try:
             with open(cache_file) as f:
@@ -262,9 +254,7 @@ def read_data_file(filepath: Path) -> pd.DataFrame:
         raise ValueError(f"Unsupported file format: {suffix}")
 
 
-def write_parquet(
-    df: pd.DataFrame, output_path: Path, compression: str = "snappy"
-):
+def write_parquet(df: pd.DataFrame, output_path: Path, compression: str = "snappy"):
     """Write DataFrame to Parquet with consistent settings.
 
     Args:
@@ -273,12 +263,10 @@ def write_parquet(
         compression: Compression algorithm ('snappy', 'gzip', 'brotli')
     """
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    df.to_parquet(
-        output_path, compression=compression, index=False, engine="pyarrow"
-    )
+    df.to_parquet(output_path, compression=compression, index=False, engine="pyarrow")
 
 
-def get_processing_stats(df: pd.DataFrame) -> Dict[str, Any]:
+def get_processing_stats(df: pd.DataFrame) -> dict[str, Any]:
     """Generate processing statistics for a DataFrame.
 
     Args:

--- a/src/corpus/quality.py
+++ b/src/corpus/quality.py
@@ -1,0 +1,266 @@
+"""Lightweight quality reporting for curated datasets."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import polars as pl  # type: ignore[import]
+
+from corpus.config import settings
+from corpus.utils import save_json
+
+
+def _numeric_dtypes() -> set[pl.PolarsDataType]:
+    """Collect numeric dtype classes available in the installed Polars."""
+
+    numeric: set[pl.PolarsDataType] = set(getattr(pl, "NUMERIC_DTYPES", []))
+    for attr in ("Decimal", "Decimal128", "Decimal256"):
+        dtype = getattr(pl, attr, None)
+        if dtype is not None:
+            numeric.add(dtype)
+    return numeric
+
+
+NUMERIC_DTYPES = _numeric_dtypes()
+
+
+def _is_numeric_dtype(dtype: pl.PolarsDataType) -> bool:
+    """Return True when dtype represents a numeric column."""
+
+    return dtype in NUMERIC_DTYPES
+
+
+def _is_categorical_dtype(dtype: pl.PolarsDataType) -> bool:
+    """Return True for textual/categorical columns."""
+
+    return dtype in {pl.Utf8, pl.Categorical, pl.Boolean}
+
+
+@dataclass(slots=True)
+class ColumnQuality:
+    """Per-column quality metrics."""
+
+    name: str
+    dtype: str
+    null_percent: float
+    unique_count: int | None
+    summary: dict[str, Any]
+
+
+class QualityReporter:
+    """Create machine-readable and HTML quality reports for curated outputs."""
+
+    def __init__(
+        self,
+        output_dir: Path | None = None,
+        top_k: int = 5,
+        base_dir: Path | None = None,
+    ) -> None:
+        self.output_dir = output_dir or settings.curated_dir / "quality"
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.top_k = top_k
+        self.base_dir = base_dir or settings.curated_dir
+
+    def profile(self, dataset_name: str, df: pl.DataFrame) -> dict[str, Any]:
+        """Generate quality report artifacts for a dataset."""
+
+        summary = self._summarize(dataset_name, df)
+        file_slug = dataset_name.replace(" ", "_").lower()
+        json_path = self.output_dir / f"{file_slug}.json"
+        html_path = self.output_dir / f"{file_slug}.html"
+
+        save_json(summary, json_path, indent=2)
+        html_path.write_text(self._render_html(summary), encoding="utf-8")
+
+        rel_json = self._relative_to_base(json_path)
+        rel_html = self._relative_to_base(html_path)
+
+        report_refs = {
+            "dataset": dataset_name,
+            "json": str(rel_json),
+            "html": str(rel_html),
+            "generated_at": summary["generated_at"],
+            "row_count": summary["row_count"],
+            "column_count": summary["column_count"],
+            "alerts": summary["alerts"],
+        }
+
+        summary["reports"] = report_refs
+        return summary
+
+    # fmt: off
+
+    def _summarize(
+        self, dataset_name: str, df: pl.DataFrame
+    ) -> dict[str, Any]:
+        """Build the JSON-friendly summary for a dataset."""
+
+        row_count = df.height
+        column_names = df.columns
+        total_cells = row_count * len(column_names)
+        total_nulls = sum(df[col].null_count() for col in column_names)
+        overall_null_percent = (
+            round((total_nulls / total_cells) * 100, 4) if total_cells else 0.0
+        )
+
+        columns: dict[str, dict[str, Any]] = {}
+        alerts: list[str] = []
+
+        for column in column_names:
+            series = df[column]
+            dtype = series.dtype
+            null_percent = (
+                round((series.null_count() / row_count) * 100, 4)
+                if row_count
+                else 0.0
+            )
+            unique_count = None
+            summary: dict[str, Any] = {}
+
+            non_null_series = series.drop_nulls()
+            if _is_numeric_dtype(dtype):
+                if not non_null_series.is_empty():
+                    summary.update(
+                        {
+                            "min": non_null_series.min(),
+                            "max": non_null_series.max(),
+                            "mean": round(float(non_null_series.mean()), 4),
+                            "std": round(float(non_null_series.std()), 4)
+                            if non_null_series.len() > 1
+                            else 0.0,
+                        }
+                    )
+            elif _is_categorical_dtype(dtype):
+                value_counts = (
+                    non_null_series.value_counts(sort=True)
+                    .head(self.top_k)
+                    .to_dict(as_series=False)
+                )
+                if value_counts:
+                    summary["top_values"] = [
+                        {"value": value, "count": count}
+                        for value, count in zip(
+                            value_counts.get(series.name, []) or [],
+                            value_counts.get("count", []) or [],
+                            strict=False,
+                        )
+                    ]
+
+            if not non_null_series.is_empty():
+                unique_count = non_null_series.n_unique()
+
+            if null_percent >= 50.0:
+                alerts.append(f"{column} has {null_percent:.2f}% nulls")
+
+            columns[column] = {
+                "dtype": str(dtype),
+                "null_percent": null_percent,
+                "unique_count": unique_count,
+                "summary": summary,
+            }
+
+        # Add high-level alerts
+        if row_count == 0:
+            alerts.append("Dataset is empty")
+        if overall_null_percent >= 25.0:
+            alerts.append("Overall null percentage exceeds 25%")
+
+        return {
+            "dataset": dataset_name,
+            "generated_at": datetime.now(UTC).isoformat(),
+            "row_count": row_count,
+            "column_count": len(column_names),
+            "overall_null_percent": overall_null_percent,
+            "columns": columns,
+            "alerts": alerts,
+        }
+
+    # fmt: on
+    # fmt: off
+
+    def _render_html(self, summary: dict[str, Any]) -> str:
+        """Render a minimal HTML report so analysts can browse locally."""
+
+        rows: list[str] = []
+        for column, metrics in summary["columns"].items():
+            column_html = [
+                f"<tr><td>{column}</td>",
+                f"<td>{metrics['dtype']}</td>",
+                f"<td>{metrics['null_percent']:.2f}%</td>",
+                f"<td>{metrics.get('unique_count', '—')}</td>",
+                "<td>",
+            ]
+
+            summary_stats = metrics["summary"]
+            if "min" in summary_stats:
+                column_html.append(
+                    "Min: {min}, Max: {max}, Mean: {mean}, Std: {std}".format(
+                        **summary_stats
+                    )
+                )
+            elif "top_values" in summary_stats:
+                top_values = ", ".join(
+                    f"{item['value']} ({item['count']})"
+                    for item in summary_stats["top_values"]
+                )
+                column_html.append(top_values)
+            else:
+                column_html.append("—")
+
+            column_html.append("</td></tr>")
+            rows.append("".join(column_html))
+
+        alerts_section = "".join(
+            f"<li>{alert}</li>" for alert in summary["alerts"]
+        )
+
+        return f"""<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+  <meta charset=\"utf-8\" />
+  <title>Quality Report - {summary['dataset']}</title>
+  <style>
+    body {{ font-family: Arial, sans-serif; margin: 1.5rem; }}
+    table {{ border-collapse: collapse; width: 100%; margin-top: 1rem; }}
+    th, td {{ border: 1px solid #ddd; padding: 0.5rem; text-align: left; }}
+    th {{ background-color: #f5f5f5; }}
+  </style>
+ </head>
+ <body>
+   <h1>Quality Report - {summary['dataset']}</h1>
+   <p>Generated: {summary['generated_at']}</p>
+    <p>Rows: {summary['row_count']} | Columns: {summary['column_count']} |
+        Overall Null %: {summary['overall_null_percent']:.2f}%</p>
+   <h2>Alerts</h2>
+   <ul>{alerts_section or '<li>No alerts detected.</li>'}</ul>
+   <h2>Columns</h2>
+   <table>
+     <thead>
+       <tr>
+         <th>Column</th>
+         <th>Type</th>
+         <th>Null %</th>
+         <th>Unique</th>
+         <th>Summary</th>
+       </tr>
+     </thead>
+     <tbody>
+       {''.join(rows)}
+     </tbody>
+   </table>
+ </body>
+</html>
+"""
+
+    # fmt: on
+
+    def _relative_to_base(self, path: Path) -> Path:
+        """Return a path relative to the curated base directory."""
+
+        try:
+            return path.relative_to(self.base_dir)
+        except ValueError:
+            return path

--- a/src/corpus/utils.py
+++ b/src/corpus/utils.py
@@ -126,6 +126,7 @@ class MetadataTracker:
             "duplicates_removed": {},
             "unmapped_texts": 0,
             "provenance_summary": {},
+            "quality_reports": {},
         }
 
     def add_row_count(self, source: str, count: int) -> None:
@@ -151,6 +152,11 @@ class MetadataTracker:
     def add_provenance_summary(self, source: str, count: int) -> None:
         """Add provenance summary."""
         self.metadata["provenance_summary"][source] = count
+
+    def add_quality_report(self, dataset: str, report: dict[str, Any]) -> None:
+        """Attach quality report references for a dataset."""
+
+        self.metadata["quality_reports"][dataset] = report
 
     def save(self, file_path: Path) -> None:
         """Save metadata to JSON."""

--- a/tests/test_quality_reports.py
+++ b/tests/test_quality_reports.py
@@ -1,0 +1,47 @@
+"""Tests for quality report generation."""
+
+from pathlib import Path
+
+import polars as pl  # type: ignore[import]
+from corpus.curate import CorpusCurator  # type: ignore[import]
+from corpus.quality import QualityReporter  # type: ignore[import]
+
+
+def test_quality_reporter_generates_files(tmp_path: Path) -> None:
+    """QualityReporter should emit JSON and HTML summaries with stats."""
+
+    df = pl.DataFrame(
+        {
+            "name": ["Alpha", "Beta", None, "Alpha"],
+            "hit_points": [100, 200, 150, None],
+        }
+    )
+
+    reporter = QualityReporter(
+        output_dir=tmp_path / "quality",
+        base_dir=tmp_path,
+    )
+
+    summary = reporter.profile("unified", df)
+
+    json_report = tmp_path / "quality" / "unified.json"
+    html_report = tmp_path / "quality" / "unified.html"
+
+    assert json_report.exists()
+    assert html_report.exists()
+    assert summary["reports"]["json"] == "quality/unified.json"
+    assert summary["columns"]["name"]["null_percent"] == 25.0
+    assert summary["columns"]["hit_points"]["summary"]["max"] == 200
+
+
+def test_curator_records_quality_metadata(tmp_path: Path) -> None:
+    """CorpusCurator should attach report metadata for datasets."""
+
+    curator = CorpusCurator(output_dir=tmp_path)
+    df = pl.DataFrame({"entity_type": ["weapon", "armor"], "value": [1, 2]})
+
+    curator._record_quality_report("demo", df)
+
+    reports = curator.metadata.metadata["quality_reports"]
+    assert "demo" in reports
+    assert reports["demo"]["reports"]["json"].endswith("demo.json")


### PR DESCRIPTION
## Summary
- add a reusable `QualityReporter` that profiles every curated dataset and emits JSON + HTML diagnostics
- wire the reporter into `CorpusCurator` so unified and per-entity exports register their report metadata
- document the new workflow and cover it with targeted unit tests

## Testing
- `poetry run ruff check --fix .`
- `poetry run ruff format .`
- `poetry run pytest`
