### PR TITLE
Finalize RAG balance and reranker enhancements

### DIFF
--- a/PROJECT_SUMMARY.md
+++ b/PROJECT_SUMMARY.md
@@ -13,9 +13,10 @@ A complete, production-ready data pipeline for curating Elden Ring game data (ba
 
 - ✅ **Carian FMG aliasing** now ingests alternate filename pairs (e.g., `ArtsName.fmg.xml`) so ash-of-war, boss, spell, and dialogue datasets survive missing canonical FMGs. See `corpus/ingest_carian_fmg.py` and `pipelines/io/carian_fmg_loader.py` for the candidate lists.
 - ✅ **Canonical + lore rebuild** completed after the alias change (items/weapons/armor/bosses/spells + `pipelines.build_lore_corpus`). Lore corpus currently holds 15,992 lines with 8,030 Carian dialogue rows.
-- ✅ **Embeddings + FAISS artifacts** regenerated locally using `all-MiniLM-L6-v2` (14,454 vectors, `embedding_strategy=weighted_text_types_v1`). Artifacts live under `data/embeddings/` and are described in `eval/rag_weighting_evaluation.md`.
-- ✅ **Benchmark runbook updated** (`eval/rag_weighting_evaluation.md`) with raw `rag.query` outputs for Radahn, Scarlet Rot, Fungus, Thorns/Gloam-Eyed, and Messmer prompts. Dialogue-heavy results surfaced for the first two prompts, highlighting a pending tuning task (reduce dialogue weighting or add category filters).
-- ⚠️ **Next tuning step**: adjust text-type weights (e.g., downgrade `dialogue`) or filter NPC rows when running general lore benchmarks so descriptive weapon/spell entries regain representation.
+- ✅ **Dialogue weighting dampened + embeddings rebuilt**. `dialogue` rows now default to a 0.7 multiplier (down from 1.5) so descriptive lore re-enters the top window; `make rag-embeddings && make rag-index` were rerun to bake the change into `data/embeddings/*`.
+- ✅ **Balanced retrieval + semantic dedup**. `rag.query` now default-interleaves dialogue, descriptions, impalers excerpts, and lore, caps any single text_type at two slots before falling back, flattens multi-line TalkMsg blocks, and skips near-duplicate dialogue if cosine similarity >0.97.
+- ✅ **Cross-encoder reranker integration**. `rag.reranker` exposes an identity + `cross-encoder/ms-marco-MiniLM-L-6-v2` reranker, annotates `reranker_score` / ordering notes, respects `--mode balanced|raw`, and records reranker metadata in `rag_index_meta.json`.
+- ✅ **Benchmark runbook updated** (`eval/rag_weighting_evaluation.md`) with embedding-only vs reranked tables for Radahn, Scarlet Rot, Fungus, Thorns/Gloam-Eyed, and Messmer prompts, showing descriptions re-entering the default top-10 while valid dialogue still appears.
 
 ## ✅ Deliverables Completed
 

--- a/TODO.md
+++ b/TODO.md
@@ -17,5 +17,5 @@
 ## RAG quality improvements
 - [x] Reweight text types so `description` and `impalers_excerpt` rows score higher than terse `effect` snippets for thematic prompts (Radahn, Scarlet Rot, etc.).
 - [x] Augment preprocessing by concatenating complementary fields (e.g., effect + description) before embedding to blend mechanics with lore context.
-- [ ] Prototype a lightweight reranker (cosine or cross-encoder) prioritizing narrative-rich passages for story-heavy searches.
+- [x] Prototype a lightweight reranker (cosine or cross-encoder) prioritizing narrative-rich passages for story-heavy searches.
 - [ ] Audit corpus coverage for Radahn/Malenia/Rot dialogue in Impalers/GitHub sources and schedule ingestion if gaps remain.

--- a/config/text_type_weights.yml
+++ b/config/text_type_weights.yml
@@ -2,7 +2,7 @@
 description: 1.4
 impalers_excerpt: 1.7
 quote: 1.3
-dialogue: 1.5
+dialogue: 0.7
 lore: 1.2
 effect: 0.7
 obtained_from: 0.8

--- a/eval/rag_weighting_evaluation.md
+++ b/eval/rag_weighting_evaluation.md
@@ -1,116 +1,209 @@
-# Weighted Text-Type Benchmark — 2025-11-18 (filter/dedup refresh)
+# Weighted Text-Type Benchmark — 2025-11-18 (filter/dedup + reranker refresh)
 
 ## Method
 - Rebuilt lore + canonical artifacts: `poetry run python -m pipelines.build_lore_corpus` (15,992 lore rows) followed by `EMBED_PROVIDER=local EMBED_MODEL=all-MiniLM-L6-v2 poetry run python -m pipelines.build_lore_embeddings --provider local --model all-MiniLM-L6-v2` (14,454 weighted MiniLM vectors, `embedding_strategy=weighted_text_types_v1`).
 - Regenerated the FAISS index via `poetry run python -m pipelines.build_rag_index` (384-dim, normalized IP search). Metadata parquet/JSON now capture the local encoder and weighting profile.
 - `rag.query` now defaults to `top_k=10`, fetches extra candidates internally, and deduplicates on normalized text so the default window remains unique-heavy. Inclusion/exclusion filters are supplied through the new `--filter` flag (e.g., `text_type!=dialogue`).
 - Queries below were executed immediately after the index refresh using combinations of the default view and the new filter flag to demonstrate balance between dialogue and descriptive entries.
+- Captured embedding-only vs. cross-encoder (`cross-encoder/ms-marco-MiniLM-L-6-v2`) reranked outputs for every prompt via a helper script. Raw captures live in `eval/reranker_benchmark.json` for reproducibility.
 
 ## Query 1 — “Radahn gravity comet”
 
-### Default (no filters)
-| Rank | Score | Category | Text Type | Source | Notes |
+### Embedding-only (balanced, no filters)
+| Rank | Score | Category | Text Type | Source | Snippet |
 | --- | --- | --- | --- | --- | --- |
-| 1 | 0.468 | npc | dialogue | carian_dialogue_fmg | “If General Radahn were to die, the stars would resume their movement.” |
-| 2 | 0.462 | npc | dialogue | carian_dialogue_fmg | “Radahn challenged the swirling constellations … arrested their cycles.” |
-| 3 | 0.460 | npc | dialogue | carian_dialogue_fmg | “Should General Radahn be defeated, the stars would once again resume their movement.” |
-| 4 | 0.455 | npc | dialogue | carian_dialogue_fmg | Variant of the star-cycle warning. |
-| 5 | 0.445 | npc | dialogue | carian_dialogue_fmg | “But General Radahn is the conqueror of the stars.” |
-| 6 | 0.441 | npc | dialogue | carian_dialogue_fmg | Festival intro describing Radahn as the strongest demigod. |
-| 7 | 0.439 | npc | dialogue | carian_dialogue_fmg | “General Radahn, mightiest demigod of the Shattering, awaits you!” |
-| 8 | 0.433 | npc | dialogue | carian_dialogue_fmg | “That Starscourge Radahn holds Ranni's fate in stasis.” |
-| 9 | 0.433 | npc | dialogue | carian_dialogue_fmg | “We are pitted against Radahn, once the strongest of the demigods.” |
-| 10 | 0.431 | npc | dialogue | carian_dialogue_fmg | “The conqueror of the stars, General Radahn.” |
+| 1 | 0.381 | weapon | description | carian_weapon_fmg | Description: Greatarrows used by General Radahn during the festival of combat... |
+| 2 | 0.468 | npc | dialogue | carian_dialogue_fmg | Dialogue: If General Radahn were to die, the stars would resume their movement. |
+| 3 | 0.376 | item | description | carian_goods_fmg | Description: One of the glintstone sorceries that manipulates gravitational f... |
+| 4 | 0.462 | npc | dialogue | carian_dialogue_fmg | Dialogue: But long ago, General Radahn challenged the swirling constellations... |
+| 5 | 0.460 | npc | dialogue | carian_dialogue_fmg | Dialogue: Should General Radahn be defeated, the stars would once again resum... |
+| 6 | 0.455 | npc | dialogue | carian_dialogue_fmg | Dialogue: And so, if General Radahn were defeated, the stars would once again... |
+| 7 | 0.445 | npc | dialogue | carian_dialogue_fmg | Dialogue: But General Radahn is the conqueror of the stars. |
+| 8 | 0.441 | npc | dialogue | carian_dialogue_fmg | Dialogue: Now, we find ourselves at a festival of combat, pitted against Rada... |
+| 9 | 0.439 | npc | dialogue | carian_dialogue_fmg | Dialogue: General Radahn, mightiest demigod of the Shattering, awaits you! |
+| 10 | 0.433 | npc | dialogue | carian_dialogue_fmg | Dialogue: That Starscourge Radahn holds Ranni's fate in stasis. |
 
-### Filtered (`--filter text_type!=dialogue`)
-| Rank | Score | Category | Text Type | Source | Notes |
+### Cross-encoder reranked (balanced, no filters)
+| Rank | Score | Category | Text Type | Source | Snippet |
 | --- | --- | --- | --- | --- | --- |
-| 1 | 0.381 | weapon | description | carian_weapon_fmg | Radahn's greatarrows (Cleanrot spear lore, gravity crest). |
-| 2 | 0.376 | item | description | carian_goods_fmg | Gravity sorcery mastered by young Radahn, pulls foes inward. |
-| 3 | 0.368 | item | description | kaggle_dlc | DLC version of Radahn's greatarrows. |
-| 4 | 0.366 | boss | drops | kaggle_dlc | Yelough Anix tunnel reward callout (Meteorite of Astel). |
-| 5 | 0.361 | spell | description | kaggle_dlc | Twin spiral glintstone projectiles, failed comet experiment. |
-| 6 | 0.358 | spell | description | kaggle_dlc | Classic comet sorcery (Karolos Conspectus). |
-| 7 | 0.337 | spell | description | kaggle_dlc | Gravity volley that drags foes to the caster. |
-| 8 | 0.331 | item | description | carian_goods_fmg | Spiral projectile variant sourced from Carian FMG. |
-| 9 | 0.330 | weapon | description | kaggle_dlc | Starscourge curved greatswords with gravity crest. |
-| 10 | 0.328 | boss | quote/drops | kaggle_dlc | Redmane Castle drop note + black flame lore excerpt. |
+| 1 | 0.376 | item | description | carian_goods_fmg | Description: One of the glintstone sorceries that manipulates gravitational f... |
+| 2 | 0.462 | npc | dialogue | carian_dialogue_fmg | Dialogue: But long ago, General Radahn challenged the swirling constellations... |
+| 3 | 0.366 | boss | drops | kaggle_dlc | Drops: Yelough Anix Tunnel: 120,000; Meteorite of Astel |
+| 4 | 0.381 | weapon | description | carian_weapon_fmg | Description: Greatarrows used by General Radahn during the festival of combat... |
+| 5 | 0.445 | npc | dialogue | carian_dialogue_fmg | Dialogue: But General Radahn is the conqueror of the stars. |
+| 6 | 0.368 | item | description | kaggle_dlc | Description: Greatarrows used by the General Radahns during the festival of c... |
+| 7 | 0.401 | npc | dialogue | carian_dialogue_fmg | Dialogue: General Radahn. |
+| 8 | 0.361 | spell | description | kaggle_dlc | Description: One of the glintstone sorceries of the Academy of Raya Lucaria.... |
+| 9 | 0.439 | npc | dialogue | carian_dialogue_fmg | Dialogue: General Radahn, mightiest demigod of the Shattering, awaits you! |
+| 10 | 0.358 | spell | description | kaggle_dlc | Description: One of the glintstone sorceries of the Academy of Raya Lucaria.F... |
+
+### Filtered (text_type!=dialogue)
+| Rank | Score | Category | Text Type | Source | Snippet |
+| --- | --- | --- | --- | --- | --- |
+| 1 | 0.381 | weapon | description | carian_weapon_fmg | Description: Greatarrows used by General Radahn during the festival of combat... |
+| 2 | 0.366 | boss | drops | kaggle_dlc | Drops: Yelough Anix Tunnel: 120,000; Meteorite of Astel |
+| 3 | 0.328 | boss | quote | kaggle_dlc | Quote: The Red Lion General wielded gravitational powers which he learned in... |
+| 4 | 0.376 | item | description | carian_goods_fmg | Description: One of the glintstone sorceries that manipulates gravitational f... |
+| 5 | 0.285 | boss | drops | kaggle_dlc | Drops: Volcano Cave: 11,000; Jar Cannon |
+| 6 | 0.368 | item | description | kaggle_dlc | Description: Greatarrows used by the General Radahns during the festival of c... |
+| 7 | 0.281 | boss | drops | kaggle_dlc | Drops: Rauh Base: 210,000; Roar of Rugalea |
+| 8 | 0.361 | spell | description | kaggle_dlc | Description: One of the glintstone sorceries of the Academy of Raya Lucaria.... |
+| 9 | 0.358 | spell | description | kaggle_dlc | Description: One of the glintstone sorceries of the Academy of Raya Lucaria.F... |
+| 10 | 0.337 | spell | description | kaggle_dlc | Description: One of the glintstone sorceries that manipulates gravitational f... |
+
+### Filtered + cross-encoder reranked
+| Rank | Score | Category | Text Type | Source | Snippet |
+| --- | --- | --- | --- | --- | --- |
+| 1 | 0.337 | spell | description | kaggle_dlc | Description: One of the glintstone sorceries that manipulates gravitational f... |
+| 2 | 0.328 | boss | quote | kaggle_dlc | Quote: The Red Lion General wielded gravitational powers which he learned in... |
+| 3 | 0.281 | boss | drops | kaggle_dlc | Drops: Rauh Base: 210,000; Roar of Rugalea |
+| 4 | 0.376 | item | description | carian_goods_fmg | Description: One of the glintstone sorceries that manipulates gravitational f... |
+| 5 | 0.366 | boss | drops | kaggle_dlc | Drops: Yelough Anix Tunnel: 120,000; Meteorite of Astel |
+| 6 | 0.305 | spell | description | kaggle_dlc | Description: One of the glintstone sorceries that manipulates gravitational f... |
+| 7 | 0.285 | boss | drops | kaggle_dlc | Drops: Volcano Cave: 11,000; Jar Cannon |
+| 8 | 0.330 | weapon | description | kaggle_dlc | Description: Curved greatswords of black steel wielded by General Radahn. A p... |
+| 9 | 0.322 | item | description | carian_goods_fmg | Description: One of the glintstone sorceries that manipulates gravitational f... |
+| 10 | 0.312 | item | description | kaggle_dlc | Description: Remembrance of Starscourge Radahn, hewn into the Erdtree. The po... |
 
 **Observations**
-- Default view still skews toward TalkMsg dialogue because 8k NPC lines dwarf other text types, but dedup prevents repeated sentences from crowding the list.
-- A single `text_type!=dialogue` filter immediately surfaces descriptive weapon/spell/boss entries from Carian FMGs and Kaggle DLC, demonstrating the new inclusion/exclusion plumbing.
+- Default view still skews toward TalkMsg dialogue because 8k NPC lines dominate, but dedup prevents repeated sentences. The cross-encoder reranker pulls descriptive Carian FMG lore, Kaggle drops, and meta-gravity spells back into the top 10 without filters.
+- A single `text_type!=dialogue` filter surfaces descriptive weapon/spell/boss entries. With reranking enabled the gravitational sorceries, great rune lore, and boss loot share roughly equal slots, demonstrating the diversity target for Phase 4/5.
 
-## Query 2 — “Scarlet rot and decay” (`--filter text_type!=dialogue`)
-| Rank | Score | Category | Text Type | Source | Notes |
+## Query 2 — “Scarlet rot and decay” (`text_type!=dialogue`)
+
+### Embedding-only
+| Rank | Score | Category | Text Type | Source | Snippet |
 | --- | --- | --- | --- | --- | --- |
-| 1 | 0.593 | spell | description | kaggle_base | Ekzykes scarlet rot breath incantation. |
-| 2 | 0.541 | item | description | kaggle_dlc | Craftable scarlet boluses (cures rot). |
-| 3 | 0.538 | item | description | carian_accessory_fmg | Pest exaltation talisman, boosts attack near rot. |
-| 4 | 0.502 | weapon | description | carian_weapon_fmg | Flame greatsword keeping rot at bay in Redmane Castle. |
-| 5 | 0.479 | armor | description | kaggle_dlc | Rot-eaten cloak (gravekeeper). |
-| 6 | 0.479 | boss | quote/drops | kaggle_dlc | Rotten Minor Erdtree avatar blurb w/ drops. |
-| 7 | 0.458 | item | description | kaggle_dlc | Scarlet rot throwables (ritual pot). |
-| 8 | 0.457 | item | impalers_excerpt | kaggle_dlc\|impalers | Capacious rot pot excerpt (meat-like mushrooms). |
-| 9 | 0.455 | item | description | carian_goods_fmg | Rot incantation thread lore. |
-| 10 | 0.444 | spell | description | kaggle_dlc | Same rot thread incantation (effect block). |
+| 1 | 0.593 | spell | description | kaggle_base | Description: Spews scarlet rot breath of Ekzykes from above Effect: ??? |
+| 2 | 0.457 | item | impalers_excerpt | kaggle_dlc|impalers | Impalers Excerpt: Craftable item prepared using a capacious cracked pot. A go... |
+| 3 | 0.479 | boss | quote | kaggle_dlc | Quote: Guardians of the Minor Erdtrees, infested with Scarlet Rot. Their larg... |
+| 4 | 0.541 | item | description | kaggle_dlc | Description: Scarlet boluses made of cave moss.Craftable item. Alleviates sca... |
+| 5 | 0.538 | item | description | carian_accessory_fmg | Description: A talisman depicting the exultation of pests. Raises attack powe... |
+| 6 | 0.502 | weapon | description | carian_weapon_fmg | Description: Greatsword featuring a flame-like undulation. Shreds enemy flesh... |
+| 7 | 0.479 | armor | description | kaggle_dlc | Description: Thick, bristly cloak eaten through by scarlet rot.The symbol of... |
+| 8 | 0.458 | item | description | kaggle_dlc | Description: Craftable item prepared using a ritual pot. Decorated with the c... |
+| 9 | 0.455 | item | description | carian_goods_fmg | Description: Incantation of the servants of rot. Secretes countless sticky th... |
+| 10 | 0.444 | spell | description | kaggle_dlc | Description: Incantation of the servants of rot. Secretes countless sticky th... |
+
+### Cross-encoder reranked
+| Rank | Score | Category | Text Type | Source | Snippet |
+| --- | --- | --- | --- | --- | --- |
+| 1 | 0.541 | item | description | kaggle_dlc | Description: Scarlet boluses made of cave moss.Craftable item. Alleviates sca... |
+| 2 | 0.457 | item | impalers_excerpt | kaggle_dlc|impalers | Impalers Excerpt: Craftable item prepared using a capacious cracked pot. A go... |
+| 3 | 0.479 | boss | quote | kaggle_dlc | Quote: Guardians of the Minor Erdtrees, infested with Scarlet Rot. Their larg... |
+| 4 | 0.392 | boss | drops | kaggle_dlc | Drops: Shadow Keep: 150,000; Aspects of the Crucible: Thorns; Scadutree Fragm... |
+| 5 | 0.432 | spell | description | kaggle_dlc | Description: Technique of Malenia, the Goddess of Rot. Creates a gigantic flo... |
+| 6 | 0.433 | item | impalers_excerpt | kaggle_dlc|impalers | Impalers Excerpt: A large, rotten bud that will never come into bloom. Materi... |
+| 7 | 0.390 | boss | quote | kaggle_dlc | Quote: In the time when there was no Erdtree, death was burned in ghostflame.... |
+| 8 | 0.434 | item | description | carian_goods_fmg | Description: Technique of Malenia, the Goddess of Rot. Creates a gigantic flo... |
+| 9 | 0.378 | weapon | impalers_excerpt | kaggle_dlc|impalers | Impalers Excerpt: Weapon of Romina, Saint of the Bud. A scarlet glaive with a... |
+| 10 | 0.458 | item | description | kaggle_dlc | Description: Craftable item prepared using a ritual pot. Decorated with the c... |
 
 **Observations**
-- Filtering away dialogue yields a healthy mix of spells, items, armor, and boss blurbs without any manual category juggling.
-- Carian accessory FMGs (talismans) now appear beside Kaggle DLC descriptions, proving the alias-aware ingestion is wired through to retrieval.
+- Filtering away dialogue yields a healthy mix of spells, items, armor, and boss blurbs without manual category juggling.
+- The reranker further amplifies restorative items (scarlet boluses) and Romina/Malenia story beats, improving thematic continuity for rot-heavy prompts without reintroducing dialogue noise.
 
-## Query 3 — “fungus mushroom armor” (default top_k=10)
-| Rank | Score | Category | Text Type | Source | Notes |
+## Query 3 — “fungus mushroom armor”
+
+### Embedding-only (balanced, no filters)
+| Rank | Score | Category | Text Type | Source | Snippet |
 | --- | --- | --- | --- | --- | --- |
-| 1 | 0.586 | item | description | kaggle_dlc | Toxic mold mushroom used as rot ward. |
-| 2 | 0.530 | item | description | kaggle_dlc | False-night mushroom dripping oil. |
-| 3 | 0.529 | item | description | kaggle_dlc | Spongy fungal growth for throwing pots. |
-| 4 | 0.512 | item | impalers_excerpt | kaggle_dlc\|impalers | Red mushroom excerpt (raw meat texture). |
-| 5 | 0.510 | item | impalers_excerpt | kaggle_dlc\|impalers | Milky-white mushroom excerpt. |
-| 6 | 0.472 | armor | description | kaggle_dlc | Mushroom crown boosting attack near rot. |
-| 7 | 0.454 | armor | description | kaggle_dlc | Mushroom chestpiece (“holy vestments”). |
-| 8 | 0.449 | armor | description | kaggle_dlc | Mushroom headpiece variant. |
-| 9 | 0.446 | armor | description | kaggle_dlc | Mushroom arms. |
-| 10 | 0.442 | armor | description | kaggle_dlc | Mushroom legs. |
+| 1 | 0.586 | item | description | kaggle_dlc | Description: A mushroom covered in toxic mold that grows in rotten lands.Mate... |
+| 2 | 0.512 | item | impalers_excerpt | kaggle_dlc|impalers | Impalers Excerpt: Red mushroom that grows in sullen lands. Material used for... |
+| 3 | 0.530 | item | description | kaggle_dlc | Description: A mushroom that grows in the false night in and around the Etern... |
+| 4 | 0.510 | item | impalers_excerpt | kaggle_dlc|impalers | Impalers Excerpt: Milky-white mushroom that grows in sullen lands. Material u... |
+| 5 | 0.529 | item | description | kaggle_dlc | Description: A fungal growth that thrives in damp thickets and elsewhere.Mate... |
+| 6 | 0.419 | item | impalers_excerpt | kaggle_dlc|impalers | Impalers Excerpt: A species of fungus known for its deathly sweet stench. Mat... |
+| 7 | 0.472 | armor | description | kaggle_dlc | Description: Mushrooms found growing all over the body. These overgrown mushr... |
+| 8 | 0.405 | armor | impalers_excerpt | kaggle_dlc|impalers | Impalers Excerpt: Armor of the broken drake warrior Igon, from a set comprise... |
+| 9 | 0.454 | armor | description | kaggle_dlc | Description: Mushrooms found growing all over the body. These overgrown mushr... |
+| 10 | 0.449 | armor | description | kaggle_dlc | Description: Mushrooms found growing all over the body. These overgrown mushr... |
+
+### Cross-encoder reranked (balanced, no filters)
+| Rank | Score | Category | Text Type | Source | Snippet |
+| --- | --- | --- | --- | --- | --- |
+| 1 | 0.472 | armor | description | kaggle_dlc | Description: Mushrooms found growing all over the body. These overgrown mushr... |
+| 2 | 0.512 | item | impalers_excerpt | kaggle_dlc|impalers | Impalers Excerpt: Red mushroom that grows in sullen lands. Material used for... |
+| 3 | 0.586 | item | description | kaggle_dlc | Description: A mushroom covered in toxic mold that grows in rotten lands.Mate... |
+| 4 | 0.510 | item | impalers_excerpt | kaggle_dlc|impalers | Impalers Excerpt: Milky-white mushroom that grows in sullen lands. Material u... |
+| 5 | 0.446 | armor | description | kaggle_dlc | Description: Mushrooms found growing all over the body. These overgrown mushr... |
+| 6 | 0.419 | item | impalers_excerpt | kaggle_dlc|impalers | Impalers Excerpt: A species of fungus known for its deathly sweet stench. Mat... |
+| 7 | 0.454 | armor | description | kaggle_dlc | Description: Mushrooms found growing all over the body. These overgrown mushr... |
+| 8 | 0.405 | armor | impalers_excerpt | kaggle_dlc|impalers | Impalers Excerpt: Armor of the broken drake warrior Igon, from a set comprise... |
+| 9 | 0.530 | item | description | kaggle_dlc | Description: A mushroom that grows in the false night in and around the Etern... |
+| 10 | 0.449 | armor | description | kaggle_dlc | Description: Mushrooms found growing all over the body. These overgrown mushr... |
 
 **Observations**
-- Dedup keeps the two Impalers excerpts (red/milky) at a single occurrence each despite identical canonical IDs sharing text in earlier runs.
-- Narrative mix spans crafting materials plus full armor set descriptions, matching the prompt intent.
+- Dedup keeps Impalers excerpts (red/milky) at one occurrence each despite identical canonical IDs sharing text in earlier runs.
+- Reranking nudges the armor descriptions slightly higher, keeping the mushroom set adjacent to crafting ingredients so annotators see gear context first.
 
-## Query 4 — “thorns death gloam-eyed queen” (`--filter text_type!=dialogue`)
-| Rank | Score | Category | Text Type | Source | Notes |
+## Query 4 — “thorns death gloam-eyed queen” (`text_type!=dialogue`)
+
+### Embedding-only
+| Rank | Score | Category | Text Type | Source | Snippet |
 | --- | --- | --- | --- | --- | --- |
-| 1 | 0.501 | item | description | carian_goods_fmg | Godskin Apostle black flame circle (Gloam-Eyed lore). |
-| 2 | 0.490 | spell | description | kaggle_dlc | Same incantation, gameplay-focused wording. |
-| 3 | 0.471 | item | description | carian_accessory_fmg | Legendary talisman engraved with Marika’s rune. |
-| 4 | 0.460 | item | description | carian_goods_fmg | Thorn sorcery discovered by exiled criminals. |
-| 5 | 0.458 | item | description | carian_accessory_fmg | Radagon rune talisman (stat boost + damage taken). |
-| 6 | 0.453 | spell | description | kaggle_dlc | Thorn trail sorcery (punishment variant). |
-| 7 | 0.447 | item | description | carian_goods_fmg | Spiral bloodthorn sorcery description. |
-| 8 | 0.446 | item | description | kaggle_dlc | Gurranq's Deathroot eye.
-| 9 | 0.444 | weapon | description | kaggle_dlc | Sacred sword of the Gloam-Eyed Queen. |
-| 10 | 0.444 | item | description | kaggle_dlc | Purifying crystal tear for Mohg's curse. |
+| 1 | 0.501 | item | description | carian_goods_fmg | Description: Superior black flame incantation of the Godskin Apostles. Summon... |
+| 2 | 0.410 | weapon | impalers_excerpt | kaggle_dlc|impalers | Impalers Excerpt: Light greatsword with gold inlaid. Weapon of Leda, the Need... |
+| 3 | 0.422 | boss | drops | kaggle_dlc | Drops: War-Dead Catacombs: 64,000; Redmane Knight Ogha Spirit Ashes; Golden S... |
+| 4 | 0.409 | boss | quote | kaggle_dlc | Quote: Valiant Gargoyles, mended with blackened corpse wax. Such is the mark... |
+| 5 | 0.490 | spell | description | kaggle_dlc | Description: Superior black flame incantation of the Godskin Apostles. Summon... |
+| 6 | 0.408 | boss | quote | kaggle_dlc | Quote: Guardians of the Minor Erdtrees, infested with Scarlet Rot. Their larg... |
+| 7 | 0.471 | item | description | carian_accessory_fmg | Description: This legendary talisman is an eye engraved with an Elden Rune, s... |
+| 8 | 0.404 | boss | quote | kaggle_dlc | Quote: A Vicious beast that has lost all reason, attacking indiscriminately.... |
+| 9 | 0.460 | item | description | carian_goods_fmg | Description: An aberrant sorcery discovered by exiled criminals. Theirs are t... |
+| 10 | 0.458 | item | description | carian_accessory_fmg | Description: This legendary talisman is an eye engraved with an Elden Rune, s... |
+
+### Cross-encoder reranked
+| Rank | Score | Category | Text Type | Source | Snippet |
+| --- | --- | --- | --- | --- | --- |
+| 1 | 0.414 | item | description | carian_accessory_fmg | Description: Sacred cloth of the Godskin Apostles, made from supple skin sewn... |
+| 2 | 0.400 | item | impalers_excerpt | kaggle_dlc|impalers | Impalers Excerpt: A Great Rune relinquished by Miquella. Broken and bereft of... |
+| 3 | 0.408 | boss | quote | kaggle_dlc | Quote: Guardians of the Minor Erdtrees, infested with Scarlet Rot. Their larg... |
+| 4 | 0.422 | boss | drops | kaggle_dlc | Drops: War-Dead Catacombs: 64,000; Redmane Knight Ogha Spirit Ashes; Golden S... |
+| 5 | 0.490 | spell | description | kaggle_dlc | Description: Superior black flame incantation of the Godskin Apostles. Summon... |
+| 6 | 0.410 | weapon | impalers_excerpt | kaggle_dlc|impalers | Impalers Excerpt: Light greatsword with gold inlaid. Weapon of Leda, the Need... |
+| 7 | 0.409 | boss | quote | kaggle_dlc | Quote: Valiant Gargoyles, mended with blackened corpse wax. Such is the mark... |
+| 8 | 0.501 | item | description | carian_goods_fmg | Description: Superior black flame incantation of the Godskin Apostles. Summon... |
+| 9 | 0.387 | armor | impalers_excerpt | kaggle_dlc|impalers | Impalers Excerpt: Robe of Count Ymir, High Priest. The front is open, exposin... |
+| 10 | 0.404 | boss | quote | kaggle_dlc | Quote: A Vicious beast that has lost all reason, attacking indiscriminately.... |
 
 **Observations**
-- Filtered view mixes Carian FMG descriptions (Marika/Radagon talismans) with Kaggle DLC spells, eliminating the duplicate dialogue problem seen in the previous report.
-- Boss weapon lore now shows up alongside consumables, giving annotators broader context for the Gloam-Eyed storyline.
+- Filtered view mixes Carian FMG descriptions (Marika/Radagon talismans) with Kaggle DLC spells, eliminating the duplicate dialogue problem from the previous report.
+- The reranker prefers lore-rich Godskin textiles and Miquella’s rune over raw drop tables, so thorn-centric narratives lead the page but drops remain present for sourcing.
 
-## Query 5 — “Messmer flame serpent blood” (default top_k=10)
-| Rank | Score | Category | Text Type | Source | Notes |
+## Query 5 — “Messmer flame serpent blood”
+
+### Embedding-only (balanced, no filters)
+| Rank | Score | Category | Text Type | Source | Snippet |
 | --- | --- | --- | --- | --- | --- |
-| 1 | 0.551 | armor | impalers_excerpt | kaggle_dlc\|impalers | Messmer helm (winged serpents guarding sealed serpent). |
-| 2 | 0.531 | spell | description | kaggle_dlc | Messmer flame orb incantation. |
-| 3 | 0.531 | armor | impalers_excerpt | kaggle_dlc\|impalers | Fire Knight armor excerpt (only ones who knew Messmer). |
-| 4 | 0.531 | armor | impalers_excerpt | kaggle_dlc\|impalers | Alternate helm text (Messmer's fire phrasing). |
-| 5 | 0.530 | armor | impalers_excerpt | kaggle_dlc\|impalers | Captain Kood helm (winged serpent companion). |
-| 6 | 0.515 | weapon | impalers_excerpt | kaggle_dlc\|impalers | Fire snake flail used to brand foes. |
-| 7 | 0.511 | item | impalers_excerpt | kaggle_dlc\|impalers | Fire-snake coil explosive (craftable). |
-| 8 | 0.484 | item | impalers_excerpt | kaggle_dlc\|impalers | Kindling that burned inside Messmer. |
-| 9 | 0.472 | spell | description | kaggle_dlc | Fire Knight serpentine flame incantation. |
-| 10 | 0.459 | item | impalers_excerpt | kaggle_dlc\|impalers | Serpentine ember crafting material. |
+| 1 | 0.531 | spell | description | kaggle_dlc | Description: An incantation of Messmer the Impaler. Summons Messmer's flame t... |
+| 2 | 0.551 | armor | impalers_excerpt | kaggle_dlc|impalers | Impalers Excerpt: Black helm of Messmer the Impaler, crowned with two intertw... |
+| 3 | 0.448 | npc | dialogue | carian_dialogue_fmg | Dialogue: Join the Serpent King, as family... |
+| 4 | 0.436 | boss | quote | kaggle_dlc | Quote: Join the Serpent King, as family... Together, we will devour the very... |
+| 5 | 0.472 | spell | description | kaggle_dlc | Description: Incantation of the Fire Knights under Messmer the Impaler's pers... |
+| 6 | 0.531 | armor | impalers_excerpt | kaggle_dlc|impalers | Impalers Excerpt: Armor of the Fire Knights under Messmer the Impaler's perso... |
+| 7 | 0.439 | npc | dialogue | carian_dialogue_fmg | Dialogue: Ahh, the flame of chaos has nestled within you. |
+| 8 | 0.424 | item | description | carian_gem_fmg | Description: This Ash of War grants an armament the Blood affinity and the fo... |
+| 9 | 0.531 | armor | impalers_excerpt | kaggle_dlc|impalers | Impalers Excerpt: Black helm of Messmer the Impaler, crowned with two intertw... |
+| 10 | 0.437 | npc | dialogue | carian_dialogue_fmg | Dialogue: Let me be your serpent... |
+
+### Cross-encoder reranked (balanced, no filters)
+| Rank | Score | Category | Text Type | Source | Snippet |
+| --- | --- | --- | --- | --- | --- |
+| 1 | 0.472 | spell | description | kaggle_dlc | Description: Incantation of the Fire Knights under Messmer the Impaler's pers... |
+| 2 | 0.551 | armor | impalers_excerpt | kaggle_dlc|impalers | Impalers Excerpt: Black helm of Messmer the Impaler, crowned with two intertw... |
+| 3 | 0.416 | npc | dialogue | carian_dialogue_fmg | Dialogue: The serpent that lurked in the shadows that night... |
+| 4 | 0.411 | boss | quote | kaggle_dlc | Quote: The great serpent of Mt. Gelmir that swallowed Praetor Rykard. Attacks... |
+| 5 | 0.531 | spell | description | kaggle_dlc | Description: An incantation of Messmer the Impaler. Summons Messmer's flame t... |
+| 6 | 0.531 | armor | impalers_excerpt | kaggle_dlc|impalers | Impalers Excerpt: Armor of the Fire Knights under Messmer the Impaler's perso... |
+| 7 | 0.422 | npc | dialogue | carian_dialogue_fmg | Dialogue: Then please. Kill the great serpent. |
+| 8 | 0.436 | boss | quote | kaggle_dlc | Quote: Join the Serpent King, as family... Together, we will devour the very... |
+| 9 | 0.424 | spell | description | kaggle_dlc | Description: The terrible power of Rykard, Lord of Blasphemy. Summons searing... |
+| 10 | 0.531 | armor | impalers_excerpt | kaggle_dlc|impalers | Impalers Excerpt: Black helm of Messmer the Impaler, crowned with two intertw... |
 
 **Observations**
 - Impalers excerpts dominate (as expected) but remain unique thanks to normalized-text dedup pushing structurally identical prose beyond the top_k window.
-- Spell and crafting entries from Kaggle DLC still surface, so cross-source corroboration remains intact.
+- The reranker boosts Fire Knight incantations/armor to the very top, so narrative-heavy Messmer lore frames the remaining dialogue instead of the other way around.
 
 ## Conclusions vs. Acceptance Criteria
 1. **Pipelines verified**: Lore, embeddings, and FAISS commands completed successfully with the local MiniLM encoder, producing 14,454 vectors and refreshed metadata artifacts.
@@ -119,4 +212,4 @@
 4. **Deduplication (AC3)**: Query helper retrieves padded candidate sets and removes near-identical text before slicing, so top_k windows contain unique prose unless the corpus genuinely lacks variety.
 5. **Carian coverage (AC4)**: Weapon, accessory, boss, and TalkMsg FMGs—including fallback aliases such as `ArtsName.fmg.xml`—flow through the canonical + lore pipelines and now appear alongside Kaggle DLC rows in the retrieval results.
 6. **Docs & evaluation (AC5)**: This report, together with the README updates, documents the new default `top_k`, filter syntax, deduplication strategy, and the end-to-end pipeline run.
-7. **Reranker foundation (AC6)**: The CLI now exposes a `--reranker` flag backed by the new `rag.reranker` module, enabling future cross-encoder experimentation.
+7. **Reranker validation (AC6)**: The CLI exposes a `--reranker` flag backed by `rag.reranker`, the benchmark tables document embedding-only vs. cross-encoder ordering for all five prompts, and raw captures are stored in `eval/reranker_benchmark.json` for auditability.

--- a/eval/reranker_benchmark.json
+++ b/eval/reranker_benchmark.json
@@ -1,0 +1,1418 @@
+{
+  "radahn_default": {
+    "meta": {
+      "label": "Radahn gravity comet",
+      "query": "Radahn gravity comet",
+      "filters": null,
+      "note": "Balanced mode, no filters"
+    },
+    "embedding": [
+      {
+        "lore_id": "weapon:2816::weighted_text_types_v1",
+        "text": "Description:\nGreatarrows used by General Radahn during the festival of combat. These are in fact the many spears with which he was stabbed by the Cleanrot Knights.\nImbued with Radahn's gravitational power.",
+        "score": 0.3809182345867157,
+        "canonical_id": "weapon:2816",
+        "category": "weapon",
+        "text_type": "description",
+        "source": "carian_weapon_fmg",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:description:1/2"
+      },
+      {
+        "lore_id": "npc:carian_speaker_316031060::weighted_text_types_v1",
+        "text": "Dialogue:\nIf General Radahn were to die, the stars would resume their movement.",
+        "score": 0.4683793783187866,
+        "canonical_id": "npc:carian_speaker_316031060",
+        "category": "npc",
+        "text_type": "dialogue",
+        "source": "carian_dialogue_fmg",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:dialogue:1/2"
+      },
+      {
+        "lore_id": "item:464::weighted_text_types_v1",
+        "text": "Description:\nOne of the glintstone sorceries that manipulates gravitational forces.\nFires numerous gravitational projectiles. Any foes struck will be pulled toward the caster.\nCharging enhances potency.\nA gravitational technique mastered by the young Radahn.\n\"I thank you for your tutelage, for now I can challenge the stars.\"",
+        "score": 0.3756685256958008,
+        "canonical_id": "item:464",
+        "category": "item",
+        "text_type": "description",
+        "source": "carian_goods_fmg",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:description:2/2"
+      },
+      {
+        "lore_id": "npc:carian_speaker_316031040::weighted_text_types_v1",
+        "text": "Dialogue:\nBut long ago, General Radahn challenged the swirling constellations, and in a crushing victory, arrested their cycles.",
+        "score": 0.4623214602470398,
+        "canonical_id": "npc:carian_speaker_316031040",
+        "category": "npc",
+        "text_type": "dialogue",
+        "source": "carian_dialogue_fmg",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:dialogue:2/2"
+      },
+      {
+        "lore_id": "npc:carian_speaker_224039010::weighted_text_types_v1",
+        "text": "Dialogue:\nShould General Radahn be defeated, the stars would once again resume their movement.",
+        "score": 0.46015751361846924,
+        "canonical_id": "npc:carian_speaker_224039010",
+        "category": "npc",
+        "text_type": "dialogue",
+        "source": "carian_dialogue_fmg",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:dialogue:3/2"
+      },
+      {
+        "lore_id": "npc:carian_speaker_224032110::weighted_text_types_v1",
+        "text": "Dialogue:\nAnd so, if General Radahn were defeated, the stars would once again resume their movement.",
+        "score": 0.45528721809387207,
+        "canonical_id": "npc:carian_speaker_224032110",
+        "category": "npc",
+        "text_type": "dialogue",
+        "source": "carian_dialogue_fmg",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:dialogue:4/2"
+      },
+      {
+        "lore_id": "npc:carian_speaker_224032090::weighted_text_types_v1",
+        "text": "Dialogue:\nBut General Radahn is the conqueror of the stars.",
+        "score": 0.4450235068798065,
+        "canonical_id": "npc:carian_speaker_224032090",
+        "category": "npc",
+        "text_type": "dialogue",
+        "source": "carian_dialogue_fmg",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:dialogue:5/2"
+      },
+      {
+        "lore_id": "npc:carian_speaker_216064020::weighted_text_types_v1",
+        "text": "Dialogue:\nNow, we find ourselves at a festival of combat, pitted against Radahn, once the strongest of the demigods.",
+        "score": 0.4406132102012634,
+        "canonical_id": "npc:carian_speaker_216064020",
+        "category": "npc",
+        "text_type": "dialogue",
+        "source": "carian_dialogue_fmg",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:dialogue:6/2"
+      },
+      {
+        "lore_id": "npc:carian_speaker_312030020::weighted_text_types_v1",
+        "text": "Dialogue:\nGeneral Radahn, mightiest demigod of the Shattering, awaits you!",
+        "score": 0.438699871301651,
+        "canonical_id": "npc:carian_speaker_312030020",
+        "category": "npc",
+        "text_type": "dialogue",
+        "source": "carian_dialogue_fmg",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:dialogue:7/2"
+      },
+      {
+        "lore_id": "npc:carian_speaker_216063040::weighted_text_types_v1",
+        "text": "Dialogue:\nThat Starscourge Radahn holds Ranni's fate in stasis.",
+        "score": 0.43276864290237427,
+        "canonical_id": "npc:carian_speaker_216063040",
+        "category": "npc",
+        "text_type": "dialogue",
+        "source": "carian_dialogue_fmg",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:dialogue:8/2"
+      }
+    ],
+    "reranked": [
+      {
+        "lore_id": "item:464::weighted_text_types_v1",
+        "text": "Description:\nOne of the glintstone sorceries that manipulates gravitational forces.\nFires numerous gravitational projectiles. Any foes struck will be pulled toward the caster.\nCharging enhances potency.\nA gravitational technique mastered by the young Radahn.\n\"I thank you for your tutelage, for now I can challenge the stars.\"",
+        "score": 0.3756685256958008,
+        "canonical_id": "item:464",
+        "category": "item",
+        "text_type": "description",
+        "source": "carian_goods_fmg",
+        "reranker_score": 2.3844316005706787,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:description:1/2"
+      },
+      {
+        "lore_id": "npc:carian_speaker_316031040::weighted_text_types_v1",
+        "text": "Dialogue:\nBut long ago, General Radahn challenged the swirling constellations, and in a crushing victory, arrested their cycles.",
+        "score": 0.4623214602470398,
+        "canonical_id": "npc:carian_speaker_316031040",
+        "category": "npc",
+        "text_type": "dialogue",
+        "source": "carian_dialogue_fmg",
+        "reranker_score": -1.3598030805587769,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:dialogue:1/2"
+      },
+      {
+        "lore_id": "boss:11::weighted_text_types_v1",
+        "text": "Drops:\nYelough Anix Tunnel: 120,000; Meteorite of Astel",
+        "score": 0.3655391335487366,
+        "canonical_id": "boss:11",
+        "category": "boss",
+        "text_type": "drops",
+        "source": "kaggle_dlc",
+        "reranker_score": -11.305245399475098,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:drops:1/2"
+      },
+      {
+        "lore_id": "weapon:2816::weighted_text_types_v1",
+        "text": "Description:\nGreatarrows used by General Radahn during the festival of combat. These are in fact the many spears with which he was stabbed by the Cleanrot Knights.\nImbued with Radahn's gravitational power.",
+        "score": 0.3809182345867157,
+        "canonical_id": "weapon:2816",
+        "category": "weapon",
+        "text_type": "description",
+        "source": "carian_weapon_fmg",
+        "reranker_score": 0.611889123916626,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:description:2/2"
+      },
+      {
+        "lore_id": "npc:carian_speaker_224032090::weighted_text_types_v1",
+        "text": "Dialogue:\nBut General Radahn is the conqueror of the stars.",
+        "score": 0.4450235068798065,
+        "canonical_id": "npc:carian_speaker_224032090",
+        "category": "npc",
+        "text_type": "dialogue",
+        "source": "carian_dialogue_fmg",
+        "reranker_score": -2.061873435974121,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:dialogue:2/2"
+      },
+      {
+        "lore_id": "item:1638::weighted_text_types_v1",
+        "text": "Description:\nGreatarrows used by the General Radahns during the festival of combat. These are in fact the many spears with which he was stabbed by the Cleanrot Knights. Imbued with Radahn's gravitational power.",
+        "score": 0.3677939772605896,
+        "canonical_id": "item:1638",
+        "category": "item",
+        "text_type": "description",
+        "source": "kaggle_dlc",
+        "reranker_score": 0.39318591356277466,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:description:3/2"
+      },
+      {
+        "lore_id": "npc:carian_speaker_20210600::weighted_text_types_v1",
+        "text": "Dialogue:\nGeneral Radahn.",
+        "score": 0.40101921558380127,
+        "canonical_id": "npc:carian_speaker_20210600",
+        "category": "npc",
+        "text_type": "dialogue",
+        "source": "carian_dialogue_fmg",
+        "reranker_score": -2.687272787094116,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:dialogue:3/2"
+      },
+      {
+        "lore_id": "spell:191::weighted_text_types_v1",
+        "text": "Description:\nOne of the glintstone sorceries of the Academy of Raya Lucaria. Fires twin projectiles that form a spiral as they travel. This sorcery can be cast repeatedly and while in motion. Charging enhances potency. A sorcery of the Karolos Conspectus, the most venerable of the academy. This was the product of a failed attempt to create a new comet. NOTE: This was changed with Patch 1.07 as follows: The Attack Power was Increased.\n\nEffect:\nFire twin spiraling projectiles",
+        "score": 0.36097538471221924,
+        "canonical_id": "spell:191",
+        "category": "spell",
+        "text_type": "description",
+        "source": "kaggle_dlc",
+        "reranker_score": -10.227378845214844,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:description:4/2"
+      },
+      {
+        "lore_id": "npc:carian_speaker_312030020::weighted_text_types_v1",
+        "text": "Dialogue:\nGeneral Radahn, mightiest demigod of the Shattering, awaits you!",
+        "score": 0.438699871301651,
+        "canonical_id": "npc:carian_speaker_312030020",
+        "category": "npc",
+        "text_type": "dialogue",
+        "source": "carian_dialogue_fmg",
+        "reranker_score": -2.737281560897827,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:dialogue:4/2"
+      },
+      {
+        "lore_id": "spell:100::weighted_text_types_v1",
+        "text": "Description:\nOne of the glintstone sorceries of the Academy of Raya Lucaria.Fires a magical comet with a trailing tail.This sorcery can be cast repeatedly and while in motion. Charging enhances potency.A sorcery of the Karolos Conspectus, the most venerable of the academy.\n\nEffect:\nFires a magic comet with a trailing tail",
+        "score": 0.35813894867897034,
+        "canonical_id": "spell:100",
+        "category": "spell",
+        "text_type": "description",
+        "source": "kaggle_dlc",
+        "reranker_score": -10.267088890075684,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:description:5/2"
+      }
+    ]
+  },
+  "radahn_filtered": {
+    "meta": {
+      "label": "Radahn gravity comet",
+      "query": "Radahn gravity comet",
+      "filters": [
+        {
+          "column": "text_type",
+          "values": [
+            "dialogue"
+          ],
+          "operator": "exclude"
+        }
+      ],
+      "note": "Balanced mode, filter text_type!=dialogue"
+    },
+    "embedding": [
+      {
+        "lore_id": "weapon:2816::weighted_text_types_v1",
+        "text": "Description:\nGreatarrows used by General Radahn during the festival of combat. These are in fact the many spears with which he was stabbed by the Cleanrot Knights.\nImbued with Radahn's gravitational power.",
+        "score": 0.3809182345867157,
+        "canonical_id": "weapon:2816",
+        "category": "weapon",
+        "text_type": "description",
+        "source": "carian_weapon_fmg",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:description:1/2"
+      },
+      {
+        "lore_id": "boss:11::weighted_text_types_v1",
+        "text": "Drops:\nYelough Anix Tunnel: 120,000; Meteorite of Astel",
+        "score": 0.3655391335487366,
+        "canonical_id": "boss:11",
+        "category": "boss",
+        "text_type": "drops",
+        "source": "kaggle_dlc",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:drops:1/2"
+      },
+      {
+        "lore_id": "boss:158::weighted_text_types_v1",
+        "text": "Quote:\nThe Red Lion General wielded gravitational powers which he learned in Sellia during his younger days. All so he would never have to abandon his beloved but scrawny steed.\n\nDrops:\nRedmane Castle: 70,000; Remembrance of the Starscourge; Radahn's Great Rune",
+        "score": 0.32775306701660156,
+        "canonical_id": "boss:158",
+        "category": "boss",
+        "text_type": "quote",
+        "source": "kaggle_dlc",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:quote:1/2"
+      },
+      {
+        "lore_id": "item:464::weighted_text_types_v1",
+        "text": "Description:\nOne of the glintstone sorceries that manipulates gravitational forces.\nFires numerous gravitational projectiles. Any foes struck will be pulled toward the caster.\nCharging enhances potency.\nA gravitational technique mastered by the young Radahn.\n\"I thank you for your tutelage, for now I can challenge the stars.\"",
+        "score": 0.3756685256958008,
+        "canonical_id": "item:464",
+        "category": "item",
+        "text_type": "description",
+        "source": "carian_goods_fmg",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:description:2/2"
+      },
+      {
+        "lore_id": "boss:52::weighted_text_types_v1",
+        "text": "Drops:\nVolcano Cave: 11,000; Jar Cannon",
+        "score": 0.2852078974246979,
+        "canonical_id": "boss:52",
+        "category": "boss",
+        "text_type": "drops",
+        "source": "kaggle_dlc",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:drops:2/2"
+      },
+      {
+        "lore_id": "item:1638::weighted_text_types_v1",
+        "text": "Description:\nGreatarrows used by the General Radahns during the festival of combat. These are in fact the many spears with which he was stabbed by the Cleanrot Knights. Imbued with Radahn's gravitational power.",
+        "score": 0.3677939772605896,
+        "canonical_id": "item:1638",
+        "category": "item",
+        "text_type": "description",
+        "source": "kaggle_dlc",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:description:3/2"
+      },
+      {
+        "lore_id": "boss:149::weighted_text_types_v1",
+        "text": "Drops:\nRauh Base: 210,000; Roar of Rugalea",
+        "score": 0.2811800539493561,
+        "canonical_id": "boss:149",
+        "category": "boss",
+        "text_type": "drops",
+        "source": "kaggle_dlc",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:drops:3/2"
+      },
+      {
+        "lore_id": "spell:191::weighted_text_types_v1",
+        "text": "Description:\nOne of the glintstone sorceries of the Academy of Raya Lucaria. Fires twin projectiles that form a spiral as they travel. This sorcery can be cast repeatedly and while in motion. Charging enhances potency. A sorcery of the Karolos Conspectus, the most venerable of the academy. This was the product of a failed attempt to create a new comet. NOTE: This was changed with Patch 1.07 as follows: The Attack Power was Increased.\n\nEffect:\nFire twin spiraling projectiles",
+        "score": 0.36097538471221924,
+        "canonical_id": "spell:191",
+        "category": "spell",
+        "text_type": "description",
+        "source": "kaggle_dlc",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:description:4/2"
+      },
+      {
+        "lore_id": "spell:100::weighted_text_types_v1",
+        "text": "Description:\nOne of the glintstone sorceries of the Academy of Raya Lucaria.Fires a magical comet with a trailing tail.This sorcery can be cast repeatedly and while in motion. Charging enhances potency.A sorcery of the Karolos Conspectus, the most venerable of the academy.\n\nEffect:\nFires a magic comet with a trailing tail",
+        "score": 0.35813894867897034,
+        "canonical_id": "spell:100",
+        "category": "spell",
+        "text_type": "description",
+        "source": "kaggle_dlc",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:description:5/2"
+      },
+      {
+        "lore_id": "spell:44::weighted_text_types_v1",
+        "text": "Description:\nOne of the glintstone sorceries that manipulates gravitational forces. Fires numerous gravitational projectiles. Any foes struck will be pulled toward the caster. Charging enhances potency. A gravitational technique mastered by the young Radahn. \"I thank you for your tutelage, for now I can challenge the stars.\"\n\nEffect:\nPulls foes toward caster with gravity projectile volley",
+        "score": 0.33666491508483887,
+        "canonical_id": "spell:44",
+        "category": "spell",
+        "text_type": "description",
+        "source": "kaggle_dlc",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:description:6/2"
+      }
+    ],
+    "reranked": [
+      {
+        "lore_id": "spell:44::weighted_text_types_v1",
+        "text": "Description:\nOne of the glintstone sorceries that manipulates gravitational forces. Fires numerous gravitational projectiles. Any foes struck will be pulled toward the caster. Charging enhances potency. A gravitational technique mastered by the young Radahn. \"I thank you for your tutelage, for now I can challenge the stars.\"\n\nEffect:\nPulls foes toward caster with gravity projectile volley",
+        "score": 0.33666491508483887,
+        "canonical_id": "spell:44",
+        "category": "spell",
+        "text_type": "description",
+        "source": "kaggle_dlc",
+        "reranker_score": 2.3846287727355957,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:description:1/2"
+      },
+      {
+        "lore_id": "boss:158::weighted_text_types_v1",
+        "text": "Quote:\nThe Red Lion General wielded gravitational powers which he learned in Sellia during his younger days. All so he would never have to abandon his beloved but scrawny steed.\n\nDrops:\nRedmane Castle: 70,000; Remembrance of the Starscourge; Radahn's Great Rune",
+        "score": 0.32775306701660156,
+        "canonical_id": "boss:158",
+        "category": "boss",
+        "text_type": "quote",
+        "source": "kaggle_dlc",
+        "reranker_score": 0.4390943646430969,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:quote:1/2"
+      },
+      {
+        "lore_id": "boss:149::weighted_text_types_v1",
+        "text": "Drops:\nRauh Base: 210,000; Roar of Rugalea",
+        "score": 0.2811800539493561,
+        "canonical_id": "boss:149",
+        "category": "boss",
+        "text_type": "drops",
+        "source": "kaggle_dlc",
+        "reranker_score": -10.930276870727539,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:drops:1/2"
+      },
+      {
+        "lore_id": "item:464::weighted_text_types_v1",
+        "text": "Description:\nOne of the glintstone sorceries that manipulates gravitational forces.\nFires numerous gravitational projectiles. Any foes struck will be pulled toward the caster.\nCharging enhances potency.\nA gravitational technique mastered by the young Radahn.\n\"I thank you for your tutelage, for now I can challenge the stars.\"",
+        "score": 0.3756685256958008,
+        "canonical_id": "item:464",
+        "category": "item",
+        "text_type": "description",
+        "source": "carian_goods_fmg",
+        "reranker_score": 2.384432077407837,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:description:2/2"
+      },
+      {
+        "lore_id": "boss:11::weighted_text_types_v1",
+        "text": "Drops:\nYelough Anix Tunnel: 120,000; Meteorite of Astel",
+        "score": 0.3655391335487366,
+        "canonical_id": "boss:11",
+        "category": "boss",
+        "text_type": "drops",
+        "source": "kaggle_dlc",
+        "reranker_score": -11.305245399475098,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:drops:2/2"
+      },
+      {
+        "lore_id": "spell:111::weighted_text_types_v1",
+        "text": "Description:\nOne of the glintstone sorceries that manipulates gravitational forces.Fires a projectile of condensed gravitational force. Those struck by it will be pulled toward the caster.Charging enhances potency.A gravitational technique studied by the young Radahn. His master was an Alabaster Lord with skin of stone.\n\nEffect:\nPulls foes toward caster with gravity projectile",
+        "score": 0.30529946088790894,
+        "canonical_id": "spell:111",
+        "category": "spell",
+        "text_type": "description",
+        "source": "kaggle_dlc",
+        "reranker_score": 2.0909547805786133,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:description:3/2"
+      },
+      {
+        "lore_id": "boss:52::weighted_text_types_v1",
+        "text": "Drops:\nVolcano Cave: 11,000; Jar Cannon",
+        "score": 0.2852078974246979,
+        "canonical_id": "boss:52",
+        "category": "boss",
+        "text_type": "drops",
+        "source": "kaggle_dlc",
+        "reranker_score": -11.399616241455078,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:drops:3/2"
+      },
+      {
+        "lore_id": "weapon:3124::weighted_text_types_v1",
+        "text": "Description:\nCurved greatswords of black steel wielded by General Radahn.\nA pair of weapons decorated with a lion mane motif.\nRadahn earned considerable renown as the Starscourge in his youth, and it is said that it was during this time he engraved the gravity crest upon these blades.",
+        "score": 0.3297109603881836,
+        "canonical_id": "weapon:3124",
+        "category": "weapon",
+        "text_type": "description",
+        "source": "kaggle_dlc",
+        "reranker_score": 1.9714466333389282,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:description:4/2"
+      },
+      {
+        "lore_id": "item:941::weighted_text_types_v1",
+        "text": "Description:\nOne of the glintstone sorceries that manipulates gravitational forces.\nFires a projectile of condensed gravitational force. Those struck by it will be pulled toward the caster.\nCharging enhances potency.\nA gravitational technique studied by the young Radahn. His master was an Alabaster Lord with skin of stone.",
+        "score": 0.3215821087360382,
+        "canonical_id": "item:941",
+        "category": "item",
+        "text_type": "description",
+        "source": "carian_goods_fmg",
+        "reranker_score": 1.8556511402130127,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:description:5/2"
+      },
+      {
+        "lore_id": "item:1712::weighted_text_types_v1",
+        "text": "Description:\nRemembrance of Starscourge Radahn, hewn into the Erdtree. The power of its namesake can be unlocked by the Finger Reader.Alternatively, it can be used to gain a great bounty of runes. The Red Lion General wielded gravitational powers which he learned in Sellia during his younger days. All so he would never have to abandon his beloved but scrawny steed.",
+        "score": 0.3120584487915039,
+        "canonical_id": "item:1712",
+        "category": "item",
+        "text_type": "description",
+        "source": "kaggle_dlc",
+        "reranker_score": 1.609947681427002,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:description:6/2"
+      }
+    ]
+  },
+  "scarlet_rot": {
+    "meta": {
+      "label": "Scarlet rot and decay",
+      "query": "Scarlet rot and decay",
+      "filters": [
+        {
+          "column": "text_type",
+          "values": [
+            "dialogue"
+          ],
+          "operator": "exclude"
+        }
+      ],
+      "note": "Balanced mode, filter text_type!=dialogue"
+    },
+    "embedding": [
+      {
+        "lore_id": "spell:72::weighted_text_types_v1",
+        "text": "Description:\nSpews scarlet rot breath of Ekzykes from above\n\nEffect:\n???",
+        "score": 0.5934633016586304,
+        "canonical_id": "spell:72",
+        "category": "spell",
+        "text_type": "description",
+        "source": "kaggle_base",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:description:1/2"
+      },
+      {
+        "lore_id": "item:1024::weighted_text_types_v1",
+        "text": "Impalers Excerpt:\nCraftable item prepared using a capacious cracked pot.\nA goodly amount of materials is sealed inside.\nThrow at enemies to cause a large buildup of scarlet rot.\nRot is one of the divine elements of the outer gods, and eats away at life like a vicious plague.\n\nDescription:\nCraftable item prepared using a capacious cracked pot. A goodly amount of materials is sealed inside. Throw at enemies to cause a large buildup of scarlet rot. Rot is one of the divine elements of the outer gods, and eats away at life like a vicious plague.\n\nEffect:\nThrow at enemies to cause a large buildup of scarlet rot",
+        "score": 0.4566187858581543,
+        "canonical_id": "item:1024",
+        "category": "item",
+        "text_type": "impalers_excerpt",
+        "source": "kaggle_dlc|impalers",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:impalers_excerpt:1/2"
+      },
+      {
+        "lore_id": "boss:131::weighted_text_types_v1",
+        "text": "Quote:\nGuardians of the Minor Erdtrees, infested with Scarlet Rot. Their large staff can knock foes away, and their slam attack releases a cloud of rot, quickly leading to enemies\u2019 demise.\n\nDrops:\nMinor Erdtree (Caelid):: 9,600; Greenburst Crystal Tear; Flame-Shrouding Cracked Tear; Minor Erdtree (Dragonbarrow):: 91,000; Opaline Hardtear; Stonebarb Cracked Tear; Minor Erdtree (Consecrated Snowfield):: 160,000; Ruptured Crystal Tear; Thorny Cracked Tear; Elphael, Brace of the Haligtree:: 27,090; Walkway: Rotten Staff; Gateway: Lord's Rune",
+        "score": 0.4786111116409302,
+        "canonical_id": "boss:131",
+        "category": "boss",
+        "text_type": "quote",
+        "source": "kaggle_dlc",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:quote:1/2"
+      },
+      {
+        "lore_id": "item:1599::weighted_text_types_v1",
+        "text": "Description:\nScarlet boluses made of cave moss.Craftable item. Alleviates scarlet rot buildup and cures rot aliment. Scarlet rot accumulates gradually, coming into effect once the threshold is reached. Scarlet rot ailment greatly lowers HP in steady increments for a period.\n\nEffect:\nAlleviates scarlet rot buildup and cures rot.",
+        "score": 0.541102945804596,
+        "canonical_id": "item:1599",
+        "category": "item",
+        "text_type": "description",
+        "source": "kaggle_dlc",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:description:2/2"
+      },
+      {
+        "lore_id": "item:1118::weighted_text_types_v1",
+        "text": "Description:\nA talisman depicting the exultation of pests.\nRaises attack power when poisoning or rot occurs in the vicinity.\n\"Rot for the scarlet goddess. O scarlet blossoms, flourish in distant lands, and return to us, the unwanted children.\"",
+        "score": 0.5380923748016357,
+        "canonical_id": "item:1118",
+        "category": "item",
+        "text_type": "description",
+        "source": "carian_accessory_fmg",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:description:3/2"
+      },
+      {
+        "lore_id": "weapon:2484::weighted_text_types_v1",
+        "text": "Description:\nGreatsword featuring a flame-like undulation.\nShreds enemy flesh, inducing blood loss.\nScarlet rot is kept at bay with flame at Redmane Castle, and as such, this beloved sword of Jerren's eventually became the symbol of the castle itself.",
+        "score": 0.5021889209747314,
+        "canonical_id": "weapon:2484",
+        "category": "weapon",
+        "text_type": "description",
+        "source": "carian_weapon_fmg",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:description:4/2"
+      },
+      {
+        "lore_id": "armor:615::weighted_text_types_v1",
+        "text": "Description:\nThick, bristly cloak eaten through by scarlet rot.The symbol of an underground gravekeeper's station. Altered:Worn by gladiators who were driven from the colosseum.The wearer becomes a slightly easier target for foes.",
+        "score": 0.4794619679450989,
+        "canonical_id": "armor:615",
+        "category": "armor",
+        "text_type": "description",
+        "source": "kaggle_dlc",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:description:5/2"
+      },
+      {
+        "lore_id": "item:1744::weighted_text_types_v1",
+        "text": "Description:\nCraftable item prepared using a ritual pot. Decorated with the crest of scarlet wings. Throw at enemies to cause buildup of scarlet rot. The rot bubbles up from the Swamp of Aeonia, and eats away at life like a vicious plague.\n\nEffect:\nThrow at enemies to inflict Scarlet Rot",
+        "score": 0.45830869674682617,
+        "canonical_id": "item:1744",
+        "category": "item",
+        "text_type": "description",
+        "source": "kaggle_dlc",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:description:6/2"
+      },
+      {
+        "lore_id": "item:1558::weighted_text_types_v1",
+        "text": "Description:\nIncantation of the servants of rot.\nSecretes countless sticky threads, launching them forwards.\nA technique of the pale pests who crawl through the lands afflicted by scarlet rot; the abandoned children of the goddess.\n\"Do you have an interest in rot incantations?\"",
+        "score": 0.4550604224205017,
+        "canonical_id": "item:1558",
+        "category": "item",
+        "text_type": "description",
+        "source": "carian_goods_fmg",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:description:7/2"
+      },
+      {
+        "lore_id": "spell:166::weighted_text_types_v1",
+        "text": "Description:\nIncantation of the servants of rot. Secretes countless sticky threads, launching them forwards. A technique of the pale pests who crawl through the lands afflicted by scarlet rot; the abandoned children of the goddess. \"Do you have an interest in rot incantations?\"\n\nEffect:\nLaunches countless sticky threads before caster",
+        "score": 0.4440760016441345,
+        "canonical_id": "spell:166",
+        "category": "spell",
+        "text_type": "description",
+        "source": "kaggle_dlc",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:description:8/2"
+      }
+    ],
+    "reranked": [
+      {
+        "lore_id": "item:1599::weighted_text_types_v1",
+        "text": "Description:\nScarlet boluses made of cave moss.Craftable item. Alleviates scarlet rot buildup and cures rot aliment. Scarlet rot accumulates gradually, coming into effect once the threshold is reached. Scarlet rot ailment greatly lowers HP in steady increments for a period.\n\nEffect:\nAlleviates scarlet rot buildup and cures rot.",
+        "score": 0.541102945804596,
+        "canonical_id": "item:1599",
+        "category": "item",
+        "text_type": "description",
+        "source": "kaggle_dlc",
+        "reranker_score": 2.426589012145996,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:description:1/2"
+      },
+      {
+        "lore_id": "item:1024::weighted_text_types_v1",
+        "text": "Impalers Excerpt:\nCraftable item prepared using a capacious cracked pot.\nA goodly amount of materials is sealed inside.\nThrow at enemies to cause a large buildup of scarlet rot.\nRot is one of the divine elements of the outer gods, and eats away at life like a vicious plague.\n\nDescription:\nCraftable item prepared using a capacious cracked pot. A goodly amount of materials is sealed inside. Throw at enemies to cause a large buildup of scarlet rot. Rot is one of the divine elements of the outer gods, and eats away at life like a vicious plague.\n\nEffect:\nThrow at enemies to cause a large buildup of scarlet rot",
+        "score": 0.4566187858581543,
+        "canonical_id": "item:1024",
+        "category": "item",
+        "text_type": "impalers_excerpt",
+        "source": "kaggle_dlc|impalers",
+        "reranker_score": 0.787686824798584,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:impalers_excerpt:1/2"
+      },
+      {
+        "lore_id": "boss:131::weighted_text_types_v1",
+        "text": "Quote:\nGuardians of the Minor Erdtrees, infested with Scarlet Rot. Their large staff can knock foes away, and their slam attack releases a cloud of rot, quickly leading to enemies\u2019 demise.\n\nDrops:\nMinor Erdtree (Caelid):: 9,600; Greenburst Crystal Tear; Flame-Shrouding Cracked Tear; Minor Erdtree (Dragonbarrow):: 91,000; Opaline Hardtear; Stonebarb Cracked Tear; Minor Erdtree (Consecrated Snowfield):: 160,000; Ruptured Crystal Tear; Thorny Cracked Tear; Elphael, Brace of the Haligtree:: 27,090; Walkway: Rotten Staff; Gateway: Lord's Rune",
+        "score": 0.4786111116409302,
+        "canonical_id": "boss:131",
+        "category": "boss",
+        "text_type": "quote",
+        "source": "kaggle_dlc",
+        "reranker_score": 1.2159662246704102,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:quote:1/2"
+      },
+      {
+        "lore_id": "boss:88::weighted_text_types_v1",
+        "text": "Drops:\nShadow Keep: 150,000; Aspects of the Crucible: Thorns; Scadutree Fragment x2; Charo's Hidden Grave: 9,576; Scadutree Fragment; Recluses' River: 11,270 each; Scadutree Fragment each; Ancient Ruins of Rauh: 11,960; Scadutree Fragment",
+        "score": 0.39210575819015503,
+        "canonical_id": "boss:88",
+        "category": "boss",
+        "text_type": "drops",
+        "source": "kaggle_dlc",
+        "reranker_score": -11.343742370605469,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:drops:1/2"
+      },
+      {
+        "lore_id": "spell:186::weighted_text_types_v1",
+        "text": "Description:\nTechnique of Malenia, the Goddess of Rot. Creates a gigantic flower that blooms into an explosion of scarlet rot. Each time the scarlet flower blooms, Malenia's rot advances. It has bloomed twice already. With the third bloom, she will become a rue goddess.\n\nEffect:\nCreates a giant flower that explodes with scarlet rot",
+        "score": 0.43188774585723877,
+        "canonical_id": "spell:186",
+        "category": "spell",
+        "text_type": "description",
+        "source": "kaggle_dlc",
+        "reranker_score": 1.4749752283096313,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:description:2/2"
+      },
+      {
+        "lore_id": "item:1788::weighted_text_types_v1",
+        "text": "Impalers Excerpt:\nA large, rotten bud that will never come into bloom.\nMaterial used for crafting items.\nGrows in lands blighted by the scarlet rot.\nThere was a time when these buds were not touched by the scarlet rot's blight\u2014when they were the symbol of the small church deep in the ancient ruins of Rauh.\n\nDescription:\nA large, rotten bud that will never come into bloom. Material used for crafting items. Grows in lands blighted by the scarlet rot. There was a time when these buds were not touched by the scarlet rot's blightwhen they were the symbol of the small church deep in the ancient ruins of Rauh.\n\nEffect:\nMaterial used for crafting items",
+        "score": 0.43264442682266235,
+        "canonical_id": "item:1788",
+        "category": "item",
+        "text_type": "impalers_excerpt",
+        "source": "kaggle_dlc|impalers",
+        "reranker_score": -0.01195521280169487,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:impalers_excerpt:2/2"
+      },
+      {
+        "lore_id": "boss:45::weighted_text_types_v1",
+        "text": "Quote:\nIn the time when there was no Erdtree, death was burned in ghostflame. Deathbirds were the keepers of that fire.\n\nDrops:\nAcademy Gate Town:: 7,800; Ancient Death Rancor; Caelid: 15,000; Death's Poker; Mountaintops of the Giants:: 77,000; Death Ritual Spear; Apostate Derelict:: 220,000; Explosive Ghostflame; Charo's Hidden Grave: 230,000; Ash of War: Ghostflame Call",
+        "score": 0.3897600769996643,
+        "canonical_id": "boss:45",
+        "category": "boss",
+        "text_type": "quote",
+        "source": "kaggle_dlc",
+        "reranker_score": -11.275139808654785,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:quote:2/2"
+      },
+      {
+        "lore_id": "item:1787::weighted_text_types_v1",
+        "text": "Description:\nTechnique of Malenia, the Goddess of Rot.\nCreates a gigantic flower that blooms into an explosion of scarlet rot.\nEach time the scarlet flower blooms, Malenia's rot advances. It has bloomed twice already. With the third bloom, she will become a true goddess.",
+        "score": 0.43355807662010193,
+        "canonical_id": "item:1787",
+        "category": "item",
+        "text_type": "description",
+        "source": "carian_goods_fmg",
+        "reranker_score": 1.3663376569747925,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:description:3/2"
+      },
+      {
+        "lore_id": "weapon:2617::weighted_text_types_v1",
+        "text": "Impalers Excerpt:\nWeapon of Romina, Saint of the Bud.\nA scarlet glaive with a dangling bud-like blade.\nAttacks cause buildup of rot.\nOnce, in the crumbling, burning church, Romina held the bud in speechless silence.\nThat bud would become her blade.\n\nDescription:\nWeapon of Romina, Saint of the Bud. A scarlet glaive with a dangling bud-like blade. Attacks cause buildup of rot. Once, in the crumbling, burning church, Romina held the bud in speechless silence. That bud would become her blade.",
+        "score": 0.37847816944122314,
+        "canonical_id": "weapon:2617",
+        "category": "weapon",
+        "text_type": "impalers_excerpt",
+        "source": "kaggle_dlc|impalers",
+        "reranker_score": -1.9180748462677002,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:impalers_excerpt:3/2"
+      },
+      {
+        "lore_id": "item:1744::weighted_text_types_v1",
+        "text": "Description:\nCraftable item prepared using a ritual pot. Decorated with the crest of scarlet wings. Throw at enemies to cause buildup of scarlet rot. The rot bubbles up from the Swamp of Aeonia, and eats away at life like a vicious plague.\n\nEffect:\nThrow at enemies to inflict Scarlet Rot",
+        "score": 0.45830869674682617,
+        "canonical_id": "item:1744",
+        "category": "item",
+        "text_type": "description",
+        "source": "kaggle_dlc",
+        "reranker_score": 1.0941452980041504,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:description:4/2"
+      }
+    ]
+  },
+  "fungus": {
+    "meta": {
+      "label": "fungus mushroom armor",
+      "query": "fungus mushroom armor",
+      "filters": null,
+      "note": "Balanced mode, no filters"
+    },
+    "embedding": [
+      {
+        "lore_id": "item:2004::weighted_text_types_v1",
+        "text": "Description:\nA mushroom covered in toxic mold that grows in rotten lands.Material used for crafting items. A skilled hand can repurpose its toxic mold into an effective ward against scarlet rot.\n\nEffect:\nMaterial used for crafting items",
+        "score": 0.5857197642326355,
+        "canonical_id": "item:2004",
+        "category": "item",
+        "text_type": "description",
+        "source": "kaggle_dlc",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:description:1/2"
+      },
+      {
+        "lore_id": "item:1667::weighted_text_types_v1",
+        "text": "Impalers Excerpt:\nRed mushroom that grows in sullen lands.\nMaterial used for crafting items.\nEasily found everywhere in the realm of shadow.\nThe flesh of the mushroom is similar to raw meat, and can serve as pot innards.\n\nDescription:\nRed mushroom that grows in sullen lands. Material used for crafting items. Easily found everywhere in the realm of shadow. The flesh of the mushroom is similar to raw meat, and can serve as pot innards.\n\nEffect:\nMaterial used for crafting items",
+        "score": 0.5123426914215088,
+        "canonical_id": "item:1667",
+        "category": "item",
+        "text_type": "impalers_excerpt",
+        "source": "kaggle_dlc|impalers",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:impalers_excerpt:1/2"
+      },
+      {
+        "lore_id": "item:1312::weighted_text_types_v1",
+        "text": "Description:\nA mushroom that grows in the false night in and around the Eternal City.Material used for crafting items. It drips with a viscous fluid that behaves much like oil.\n\nEffect:\nMaterial used for crafting items",
+        "score": 0.5301715135574341,
+        "canonical_id": "item:1312",
+        "category": "item",
+        "text_type": "description",
+        "source": "kaggle_dlc",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:description:2/2"
+      },
+      {
+        "lore_id": "item:2084::weighted_text_types_v1",
+        "text": "Impalers Excerpt:\nMilky-white mushroom that grows in sullen lands.\nMaterial used for crafting items.\nEasily found everywhere in the realm of shadow.\nThe flesh of the mushroom is similar to raw meat, and can serve as pot innards.\n\nDescription:\nMilky-white mushroom that grows in sullen lands. Material used for crafting items. Easily found everywhere in the realm of shadow. The flesh of the mushroom is similar to raw meat, and can serve as pot innards.\n\nEffect:\nMaterial used for crafting items",
+        "score": 0.5099503397941589,
+        "canonical_id": "item:2084",
+        "category": "item",
+        "text_type": "impalers_excerpt",
+        "source": "kaggle_dlc|impalers",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:impalers_excerpt:2/2"
+      },
+      {
+        "lore_id": "item:1371::weighted_text_types_v1",
+        "text": "Description:\nA fungal growth that thrives in damp thickets and elsewhere.Material used for crafting items.Its thick, spongy flesh makes it a key component in throwing pots.\n\nEffect:\nMaterial used for crafting items",
+        "score": 0.5294705033302307,
+        "canonical_id": "item:1371",
+        "category": "item",
+        "text_type": "description",
+        "source": "kaggle_dlc",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:description:3/2"
+      },
+      {
+        "lore_id": "item:763::weighted_text_types_v1",
+        "text": "Impalers Excerpt:\nA species of fungus known for its deathly sweet stench.\nMaterial used for crafting items.\nFound by hunting man-flies.\nCultivated using the flesh and blood of man-flies, it can serve as pot innards.\n\nDescription:\nA species of fungus known for its deathly sweet stench. Material used for crafting items. Found by hunting man-flies. Cultivated using the flesh and blood of man-flies, it can serve as pot innards.\n\nEffect:\nMaterial used for crafting items",
+        "score": 0.4189947247505188,
+        "canonical_id": "item:763",
+        "category": "item",
+        "text_type": "impalers_excerpt",
+        "source": "kaggle_dlc|impalers",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:impalers_excerpt:3/2"
+      },
+      {
+        "lore_id": "armor:488::weighted_text_types_v1",
+        "text": "Description:\nMushrooms found growing all over the body. These overgrown mushrooms form a towering headpiece. Raises attack power when something nearby suffers from poison or rot. Long ago, great lords served the scarlet rot. Perhaps such fungal bodies served as their crowns.",
+        "score": 0.47188490629196167,
+        "canonical_id": "armor:488",
+        "category": "armor",
+        "text_type": "description",
+        "source": "kaggle_dlc",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:description:4/2"
+      },
+      {
+        "lore_id": "armor:375::weighted_text_types_v1",
+        "text": "Impalers Excerpt:\nArmor of the broken drake warrior Igon, from a set comprised of a miscellany of parts. Filthy belongings are attached to this tattered piece of protective-wear.\nThe poor scavenger of battlefields found honor through Dragon Communion.\n\nDescription:\nArmor of the broken drake warrior Igon, from a set comprised of a miscellany of parts. Filthy belongings are attached to this tattered piece of protective-wear. The poor scavenger of battlefields found honor through Dragon Communion.",
+        "score": 0.40505343675613403,
+        "canonical_id": "armor:375",
+        "category": "armor",
+        "text_type": "impalers_excerpt",
+        "source": "kaggle_dlc|impalers",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:impalers_excerpt:4/2"
+      },
+      {
+        "lore_id": "armor:487::weighted_text_types_v1",
+        "text": "Description:\nMushrooms found growing all over the body. These overgrown mushroom have colonized the torso. To those enraptured by the scarlet rot, they are holy vestments that root one to the earth.",
+        "score": 0.45400434732437134,
+        "canonical_id": "armor:487",
+        "category": "armor",
+        "text_type": "description",
+        "source": "kaggle_dlc",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:description:5/2"
+      },
+      {
+        "lore_id": "armor:489::weighted_text_types_v1",
+        "text": "Description:\nMushrooms found growing all over the body. These overgrown mushroom have colonized the head. To those enraptured by the scarlet rot, they are holy vestments that root one to the earth.",
+        "score": 0.44909149408340454,
+        "canonical_id": "armor:489",
+        "category": "armor",
+        "text_type": "description",
+        "source": "kaggle_dlc",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:description:6/2"
+      }
+    ],
+    "reranked": [
+      {
+        "lore_id": "armor:488::weighted_text_types_v1",
+        "text": "Description:\nMushrooms found growing all over the body. These overgrown mushrooms form a towering headpiece. Raises attack power when something nearby suffers from poison or rot. Long ago, great lords served the scarlet rot. Perhaps such fungal bodies served as their crowns.",
+        "score": 0.47188490629196167,
+        "canonical_id": "armor:488",
+        "category": "armor",
+        "text_type": "description",
+        "source": "kaggle_dlc",
+        "reranker_score": 1.247399091720581,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:description:1/2"
+      },
+      {
+        "lore_id": "item:1667::weighted_text_types_v1",
+        "text": "Impalers Excerpt:\nRed mushroom that grows in sullen lands.\nMaterial used for crafting items.\nEasily found everywhere in the realm of shadow.\nThe flesh of the mushroom is similar to raw meat, and can serve as pot innards.\n\nDescription:\nRed mushroom that grows in sullen lands. Material used for crafting items. Easily found everywhere in the realm of shadow. The flesh of the mushroom is similar to raw meat, and can serve as pot innards.\n\nEffect:\nMaterial used for crafting items",
+        "score": 0.5123426914215088,
+        "canonical_id": "item:1667",
+        "category": "item",
+        "text_type": "impalers_excerpt",
+        "source": "kaggle_dlc|impalers",
+        "reranker_score": -0.9131402969360352,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:impalers_excerpt:1/2"
+      },
+      {
+        "lore_id": "item:2004::weighted_text_types_v1",
+        "text": "Description:\nA mushroom covered in toxic mold that grows in rotten lands.Material used for crafting items. A skilled hand can repurpose its toxic mold into an effective ward against scarlet rot.\n\nEffect:\nMaterial used for crafting items",
+        "score": 0.5857197642326355,
+        "canonical_id": "item:2004",
+        "category": "item",
+        "text_type": "description",
+        "source": "kaggle_dlc",
+        "reranker_score": -0.814146876335144,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:description:2/2"
+      },
+      {
+        "lore_id": "item:2084::weighted_text_types_v1",
+        "text": "Impalers Excerpt:\nMilky-white mushroom that grows in sullen lands.\nMaterial used for crafting items.\nEasily found everywhere in the realm of shadow.\nThe flesh of the mushroom is similar to raw meat, and can serve as pot innards.\n\nDescription:\nMilky-white mushroom that grows in sullen lands. Material used for crafting items. Easily found everywhere in the realm of shadow. The flesh of the mushroom is similar to raw meat, and can serve as pot innards.\n\nEffect:\nMaterial used for crafting items",
+        "score": 0.5099503397941589,
+        "canonical_id": "item:2084",
+        "category": "item",
+        "text_type": "impalers_excerpt",
+        "source": "kaggle_dlc|impalers",
+        "reranker_score": -1.3764902353286743,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:impalers_excerpt:2/2"
+      },
+      {
+        "lore_id": "armor:486::weighted_text_types_v1",
+        "text": "Description:\nMushrooms found growing all over the body. These overgrown mushroom have colonized the arms. To those enraptured by the scarlet rot, they are holy vestments that root one to the earth.",
+        "score": 0.44592195749282837,
+        "canonical_id": "armor:486",
+        "category": "armor",
+        "text_type": "description",
+        "source": "kaggle_dlc",
+        "reranker_score": -0.9943055510520935,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:description:3/2"
+      },
+      {
+        "lore_id": "item:763::weighted_text_types_v1",
+        "text": "Impalers Excerpt:\nA species of fungus known for its deathly sweet stench.\nMaterial used for crafting items.\nFound by hunting man-flies.\nCultivated using the flesh and blood of man-flies, it can serve as pot innards.\n\nDescription:\nA species of fungus known for its deathly sweet stench. Material used for crafting items. Found by hunting man-flies. Cultivated using the flesh and blood of man-flies, it can serve as pot innards.\n\nEffect:\nMaterial used for crafting items",
+        "score": 0.4189947247505188,
+        "canonical_id": "item:763",
+        "category": "item",
+        "text_type": "impalers_excerpt",
+        "source": "kaggle_dlc|impalers",
+        "reranker_score": -6.984164714813232,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:impalers_excerpt:3/2"
+      },
+      {
+        "lore_id": "armor:487::weighted_text_types_v1",
+        "text": "Description:\nMushrooms found growing all over the body. These overgrown mushroom have colonized the torso. To those enraptured by the scarlet rot, they are holy vestments that root one to the earth.",
+        "score": 0.45400434732437134,
+        "canonical_id": "armor:487",
+        "category": "armor",
+        "text_type": "description",
+        "source": "kaggle_dlc",
+        "reranker_score": -1.7892637252807617,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:description:4/2"
+      },
+      {
+        "lore_id": "armor:375::weighted_text_types_v1",
+        "text": "Impalers Excerpt:\nArmor of the broken drake warrior Igon, from a set comprised of a miscellany of parts. Filthy belongings are attached to this tattered piece of protective-wear.\nThe poor scavenger of battlefields found honor through Dragon Communion.\n\nDescription:\nArmor of the broken drake warrior Igon, from a set comprised of a miscellany of parts. Filthy belongings are attached to this tattered piece of protective-wear. The poor scavenger of battlefields found honor through Dragon Communion.",
+        "score": 0.40505343675613403,
+        "canonical_id": "armor:375",
+        "category": "armor",
+        "text_type": "impalers_excerpt",
+        "source": "kaggle_dlc|impalers",
+        "reranker_score": -10.63820743560791,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:impalers_excerpt:4/2"
+      },
+      {
+        "lore_id": "item:1312::weighted_text_types_v1",
+        "text": "Description:\nA mushroom that grows in the false night in and around the Eternal City.Material used for crafting items. It drips with a viscous fluid that behaves much like oil.\n\nEffect:\nMaterial used for crafting items",
+        "score": 0.5301715135574341,
+        "canonical_id": "item:1312",
+        "category": "item",
+        "text_type": "description",
+        "source": "kaggle_dlc",
+        "reranker_score": -1.9503936767578125,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:description:5/2"
+      },
+      {
+        "lore_id": "armor:489::weighted_text_types_v1",
+        "text": "Description:\nMushrooms found growing all over the body. These overgrown mushroom have colonized the head. To those enraptured by the scarlet rot, they are holy vestments that root one to the earth.",
+        "score": 0.44909149408340454,
+        "canonical_id": "armor:489",
+        "category": "armor",
+        "text_type": "description",
+        "source": "kaggle_dlc",
+        "reranker_score": -2.341740608215332,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:description:6/2"
+      }
+    ]
+  },
+  "thorns": {
+    "meta": {
+      "label": "thorns death gloam-eyed queen",
+      "query": "thorns death gloam-eyed queen",
+      "filters": [
+        {
+          "column": "text_type",
+          "values": [
+            "dialogue"
+          ],
+          "operator": "exclude"
+        }
+      ],
+      "note": "Balanced mode, filter text_type!=dialogue"
+    },
+    "embedding": [
+      {
+        "lore_id": "item:317::weighted_text_types_v1",
+        "text": "Description:\nSuperior black flame incantation of the Godskin Apostles.\nSummons a circle of black flame pillars around the caster.\nCharging increases the size of the circle.\nThe Gloam-Eyed Queen led the apostles. It is said that she was an Empyrean chosen by the Fingers.",
+        "score": 0.5006847977638245,
+        "canonical_id": "item:317",
+        "category": "item",
+        "text_type": "description",
+        "source": "carian_goods_fmg",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:description:1/2"
+      },
+      {
+        "lore_id": "weapon:1701::weighted_text_types_v1",
+        "text": "Impalers Excerpt:\nLight greatsword with gold inlaid. \nWeapon of Leda, the Needle Knight.\nDeals holy damage.\nThough polished to a mirror sheen, this blade still reeks with the stench of crusted blood that lingers from the cull of her knightly comrades.\n\nDescription:\nLight greatsword with gold inlaid. Weapon of Leda, the Needle Knight. Deals holy damage. Though polished to a mirror sheen, this blade still reeks with the stench of crusted blood that lingers from the cull of her knightly comrades.",
+        "score": 0.4096152186393738,
+        "canonical_id": "weapon:1701",
+        "category": "weapon",
+        "text_type": "impalers_excerpt",
+        "source": "kaggle_dlc|impalers",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:impalers_excerpt:1/2"
+      },
+      {
+        "lore_id": "boss:133::weighted_text_types_v1",
+        "text": "Drops:\nWar-Dead Catacombs: 64,000; Redmane Knight Ogha Spirit Ashes; Golden Seed; Grand Cloister: 11,193; Golden Seed; Elphael, Brace of the Haligtree: 26,460; Golden Seed",
+        "score": 0.42182689905166626,
+        "canonical_id": "boss:133",
+        "category": "boss",
+        "text_type": "drops",
+        "source": "kaggle_dlc",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:drops:1/2"
+      },
+      {
+        "lore_id": "boss:19::weighted_text_types_v1",
+        "text": "Quote:\nValiant Gargoyles, mended with blackened corpse wax. Such is the mark of those who serve Maliketh, the Black Blade.\n\nDrops:\nBestial Sanctum:: 88,000; Gargoyle's Blackblade; Gargoyle's Black Halberd; Forbidden Lands:: 60,000; Gargoyle's Black Axe; Gargoyle's Black Blades",
+        "score": 0.40879639983177185,
+        "canonical_id": "boss:19",
+        "category": "boss",
+        "text_type": "quote",
+        "source": "kaggle_dlc",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:quote:1/2"
+      },
+      {
+        "lore_id": "spell:24::weighted_text_types_v1",
+        "text": "Description:\nSuperior black flame incantation of the Godskin Apostles. Summons a circle of black flame pillars around the caster. Charging increases the size of the circle. The Gloam-Eyed Queen led the apostles. It is said that she was an Empyrean chosen by the Fingers.\n\nEffect:\nSummons circle of black flame pillars around caster.",
+        "score": 0.48998188972473145,
+        "canonical_id": "spell:24",
+        "category": "spell",
+        "text_type": "description",
+        "source": "kaggle_dlc",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:description:2/2"
+      },
+      {
+        "lore_id": "boss:131::weighted_text_types_v1",
+        "text": "Quote:\nGuardians of the Minor Erdtrees, infested with Scarlet Rot. Their large staff can knock foes away, and their slam attack releases a cloud of rot, quickly leading to enemies\u2019 demise.\n\nDrops:\nMinor Erdtree (Caelid):: 9,600; Greenburst Crystal Tear; Flame-Shrouding Cracked Tear; Minor Erdtree (Dragonbarrow):: 91,000; Opaline Hardtear; Stonebarb Cracked Tear; Minor Erdtree (Consecrated Snowfield):: 160,000; Ruptured Crystal Tear; Thorny Cracked Tear; Elphael, Brace of the Haligtree:: 27,090; Walkway: Rotten Staff; Gateway: Lord's Rune",
+        "score": 0.4077415466308594,
+        "canonical_id": "boss:131",
+        "category": "boss",
+        "text_type": "quote",
+        "source": "kaggle_dlc",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:quote:2/2"
+      },
+      {
+        "lore_id": "item:1286::weighted_text_types_v1",
+        "text": "Description:\nThis legendary talisman is an eye engraved with an Elden Rune, said to be the seal of Queen Marika.\nGreatly raises mind, intelligence, faith, and arcane, but also increases damage taken by a similar measure.\nSolemn duty weighs upon the one beholden; not unlike a gnawing curse from which there is no deliverance.",
+        "score": 0.4711456894874573,
+        "canonical_id": "item:1286",
+        "category": "item",
+        "text_type": "description",
+        "source": "carian_accessory_fmg",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:description:3/2"
+      },
+      {
+        "lore_id": "boss:115::weighted_text_types_v1",
+        "text": "Quote:\nA Vicious beast that has lost all reason, attacking indiscriminately.\n\nDrops:\nUnsightly Catacombs: Unsightly Catacombs :; 9400 Runes; Perfumer Tricia Ashes Redmane Castle :; 16000 Runes; Ruins Greatsword",
+        "score": 0.4036739766597748,
+        "canonical_id": "boss:115",
+        "category": "boss",
+        "text_type": "quote",
+        "source": "kaggle_dlc",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:quote:3/2"
+      },
+      {
+        "lore_id": "item:397::weighted_text_types_v1",
+        "text": "Description:\nAn aberrant sorcery discovered by exiled criminals.\nTheirs are the sorceries most reviled by the academy.\nWounds the caster with thorns of sin, sending a trail of bloodthorns running over the ground to impale enemies from below.\nThis sorcery can be cast repeatedly.\nThe guilty, their eyes gouged by thorns, lived in eternal darkness. There, they discovered the blood star.",
+        "score": 0.4596211612224579,
+        "canonical_id": "item:397",
+        "category": "item",
+        "text_type": "description",
+        "source": "carian_goods_fmg",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:description:4/2"
+      },
+      {
+        "lore_id": "item:1625::weighted_text_types_v1",
+        "text": "Description:\nThis legendary talisman is an eye engraved with an Elden Rune, said to be the seal of King Consort Radagon.\nGreatly raises vigor, endurance, strength, and dexterity, but also increases damage taken by a similar measure.\nSolemn duty weighs upon the one beholden; not unlike a gnawing curse from which there is no deliverance.",
+        "score": 0.45792141556739807,
+        "canonical_id": "item:1625",
+        "category": "item",
+        "text_type": "description",
+        "source": "carian_accessory_fmg",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:description:5/2"
+      }
+    ],
+    "reranked": [
+      {
+        "lore_id": "item:877::weighted_text_types_v1",
+        "text": "Description:\nSacred cloth of the Godskin Apostles, made from supple skin sewn together.\nSuccessive attacks restore HP.\nThe Gloam-Eyed Queen cradles newborn apostles swaddled in this cloth. Soon they will grow to become the death of the gods.",
+        "score": 0.41375356912612915,
+        "canonical_id": "item:877",
+        "category": "item",
+        "text_type": "description",
+        "source": "carian_accessory_fmg",
+        "reranker_score": 2.9659435749053955,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:description:1/2"
+      },
+      {
+        "lore_id": "item:1337::weighted_text_types_v1",
+        "text": "Impalers Excerpt:\nA Great Rune relinquished by Miquella.\nBroken and bereft of its bounty, it retains naught but the power to resist charms.\nMiquella set off for the tower enshrouded by shadow, abandoning everything\u2014his golden flesh, his blinding strength, even his fate.\nAll in an effort to bury the original sin. To embrace the whole of it, and be reborn as a new god.\n\nDescription:\nA Great Rune relinquished by Miquella. Broken and bereft of its bounty, it retains naught but the power to resist charms. Miquella set off for the tower enshrouded by shadow, abandoning everything\u2014his golden flesh, his blinding strength, even his fate. All in an effort to bury the original sin. To embrace the whole of it, and be reborn as a new god.\n\nObtained From:\nScadutree Base\n\nEffect:\nRetains naught but the power to resist charms",
+        "score": 0.39965111017227173,
+        "canonical_id": "item:1337",
+        "category": "item",
+        "text_type": "impalers_excerpt",
+        "source": "kaggle_dlc|impalers",
+        "reranker_score": -11.195491790771484,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:impalers_excerpt:1/2"
+      },
+      {
+        "lore_id": "boss:131::weighted_text_types_v1",
+        "text": "Quote:\nGuardians of the Minor Erdtrees, infested with Scarlet Rot. Their large staff can knock foes away, and their slam attack releases a cloud of rot, quickly leading to enemies\u2019 demise.\n\nDrops:\nMinor Erdtree (Caelid):: 9,600; Greenburst Crystal Tear; Flame-Shrouding Cracked Tear; Minor Erdtree (Dragonbarrow):: 91,000; Opaline Hardtear; Stonebarb Cracked Tear; Minor Erdtree (Consecrated Snowfield):: 160,000; Ruptured Crystal Tear; Thorny Cracked Tear; Elphael, Brace of the Haligtree:: 27,090; Walkway: Rotten Staff; Gateway: Lord's Rune",
+        "score": 0.4077415466308594,
+        "canonical_id": "boss:131",
+        "category": "boss",
+        "text_type": "quote",
+        "source": "kaggle_dlc",
+        "reranker_score": -10.464825630187988,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:quote:1/2"
+      },
+      {
+        "lore_id": "boss:133::weighted_text_types_v1",
+        "text": "Drops:\nWar-Dead Catacombs: 64,000; Redmane Knight Ogha Spirit Ashes; Golden Seed; Grand Cloister: 11,193; Golden Seed; Elphael, Brace of the Haligtree: 26,460; Golden Seed",
+        "score": 0.42182689905166626,
+        "canonical_id": "boss:133",
+        "category": "boss",
+        "text_type": "drops",
+        "source": "kaggle_dlc",
+        "reranker_score": -11.266422271728516,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:drops:1/2"
+      },
+      {
+        "lore_id": "spell:24::weighted_text_types_v1",
+        "text": "Description:\nSuperior black flame incantation of the Godskin Apostles. Summons a circle of black flame pillars around the caster. Charging increases the size of the circle. The Gloam-Eyed Queen led the apostles. It is said that she was an Empyrean chosen by the Fingers.\n\nEffect:\nSummons circle of black flame pillars around caster.",
+        "score": 0.48998188972473145,
+        "canonical_id": "spell:24",
+        "category": "spell",
+        "text_type": "description",
+        "source": "kaggle_dlc",
+        "reranker_score": 0.39644956588745117,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:description:2/2"
+      },
+      {
+        "lore_id": "weapon:1701::weighted_text_types_v1",
+        "text": "Impalers Excerpt:\nLight greatsword with gold inlaid. \nWeapon of Leda, the Needle Knight.\nDeals holy damage.\nThough polished to a mirror sheen, this blade still reeks with the stench of crusted blood that lingers from the cull of her knightly comrades.\n\nDescription:\nLight greatsword with gold inlaid. Weapon of Leda, the Needle Knight. Deals holy damage. Though polished to a mirror sheen, this blade still reeks with the stench of crusted blood that lingers from the cull of her knightly comrades.",
+        "score": 0.4096152186393738,
+        "canonical_id": "weapon:1701",
+        "category": "weapon",
+        "text_type": "impalers_excerpt",
+        "source": "kaggle_dlc|impalers",
+        "reranker_score": -11.245357513427734,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:impalers_excerpt:2/2"
+      },
+      {
+        "lore_id": "boss:19::weighted_text_types_v1",
+        "text": "Quote:\nValiant Gargoyles, mended with blackened corpse wax. Such is the mark of those who serve Maliketh, the Black Blade.\n\nDrops:\nBestial Sanctum:: 88,000; Gargoyle's Blackblade; Gargoyle's Black Halberd; Forbidden Lands:: 60,000; Gargoyle's Black Axe; Gargoyle's Black Blades",
+        "score": 0.40879639983177185,
+        "canonical_id": "boss:19",
+        "category": "boss",
+        "text_type": "quote",
+        "source": "kaggle_dlc",
+        "reranker_score": -11.162031173706055,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:quote:2/2"
+      },
+      {
+        "lore_id": "item:317::weighted_text_types_v1",
+        "text": "Description:\nSuperior black flame incantation of the Godskin Apostles.\nSummons a circle of black flame pillars around the caster.\nCharging increases the size of the circle.\nThe Gloam-Eyed Queen led the apostles. It is said that she was an Empyrean chosen by the Fingers.",
+        "score": 0.5006847977638245,
+        "canonical_id": "item:317",
+        "category": "item",
+        "text_type": "description",
+        "source": "carian_goods_fmg",
+        "reranker_score": 0.32629600167274475,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:description:3/2"
+      },
+      {
+        "lore_id": "armor:252::weighted_text_types_v1",
+        "text": "Impalers Excerpt:\nRobe of Count Ymir, High Priest.\nThe front is open, exposing the squirming fingers beneath.\nThis robe is the image of his fervent desire having broken free, laying bare his greatest wish, and wearing it enhances finger sorceries.\n\"I will be the true mother.\nMy fingers will grant us redemption!\"\n\nDescription:\nRobe of Count Ymir, High Priest. The front is open, exposing the squirming fingers beneath. This robe is the image of his fervent desire having broken free, laying bare his greatest wish, and wearing it enhances finger sorceries. \"I will be the true mother. My fingers will grant us redemption!\"",
+        "score": 0.38731926679611206,
+        "canonical_id": "armor:252",
+        "category": "armor",
+        "text_type": "impalers_excerpt",
+        "source": "kaggle_dlc|impalers",
+        "reranker_score": -11.332624435424805,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:impalers_excerpt:3/2"
+      },
+      {
+        "lore_id": "boss:115::weighted_text_types_v1",
+        "text": "Quote:\nA Vicious beast that has lost all reason, attacking indiscriminately.\n\nDrops:\nUnsightly Catacombs: Unsightly Catacombs :; 9400 Runes; Perfumer Tricia Ashes Redmane Castle :; 16000 Runes; Ruins Greatsword",
+        "score": 0.4036739766597748,
+        "canonical_id": "boss:115",
+        "category": "boss",
+        "text_type": "quote",
+        "source": "kaggle_dlc",
+        "reranker_score": -11.359855651855469,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:quote:3/2"
+      }
+    ]
+  },
+  "messmer": {
+    "meta": {
+      "label": "Messmer flame serpent blood",
+      "query": "Messmer flame serpent blood",
+      "filters": null,
+      "note": "Balanced mode, no filters"
+    },
+    "embedding": [
+      {
+        "lore_id": "spell:149::weighted_text_types_v1",
+        "text": "Description:\nAn incantation of Messmer the Impaler. Summons Messmer's flame to form a giant floating orb. The orb soars toward a foe, crashes into the earth, and explodes after a brief delay. Charging enhances potency. Messmer despised his own fire. Time and time again he hoped to rid himself of it, but ever did it burn.\n\nEffect:\nShapes Messmer's flame into a giant orb that soars at foe",
+        "score": 0.5309575200080872,
+        "canonical_id": "spell:149",
+        "category": "spell",
+        "text_type": "description",
+        "source": "kaggle_dlc",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:description:1/2"
+      },
+      {
+        "lore_id": "armor:480::weighted_text_types_v1",
+        "text": "Impalers Excerpt:\nBlack helm of Messmer the Impaler, crowned with two intertwined winged serpents.\nSlightly enhances incantations of Messmer's flame as well as Fire Knight skills.\nThe winged snakes were Messmer's constant companions.\nThey were there when the base serpent was sealed away behind his eye. They were there through his eternity of suffering. They will accompany him yet, in his hideous new form born when he destroyed the grace granted by his mother. They have accepted his fate as much as he.\n\nDescription:\nBlack helm of Messmer the Impaler, crowned with two intertwined winged serpents.Slightly enhances incantations of Messmer's flame as well as Fire Knight skills.The winged snakes were Messmer's constant companions.They were there when the base serpent was sealed away behind his eye. They were there through his eternity of suffering. They will accompany him yet, in his hideous new form born when he destroyed the grace granted by his mother. They have accepted his fate as much as he.",
+        "score": 0.5512473583221436,
+        "canonical_id": "armor:480",
+        "category": "armor",
+        "text_type": "impalers_excerpt",
+        "source": "kaggle_dlc|impalers",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:impalers_excerpt:1/2"
+      },
+      {
+        "lore_id": "npc:carian_speaker_20300310::weighted_text_types_v1",
+        "text": "Dialogue:\nJoin the Serpent King, as family...",
+        "score": 0.4477306008338928,
+        "canonical_id": "npc:carian_speaker_20300310",
+        "category": "npc",
+        "text_type": "dialogue",
+        "source": "carian_dialogue_fmg",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:dialogue:1/2"
+      },
+      {
+        "lore_id": "boss:151::weighted_text_types_v1",
+        "text": "Quote:\nJoin the Serpent King, as family... Together, we will devour the very gods!\n\nDrops:\nVolcano Manor: 130.000; Rykard's Great Rune; Remembrance of the Blasphemous",
+        "score": 0.4356585144996643,
+        "canonical_id": "boss:151",
+        "category": "boss",
+        "text_type": "quote",
+        "source": "kaggle_dlc",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:quote:1/2"
+      },
+      {
+        "lore_id": "spell:74::weighted_text_types_v1",
+        "text": "Description:\nIncantation of the Fire Knights under Messmer the Impaler's personal command. Launch a serpentine flame that bends and curls in pursuit of its foe. Charging enhances potency. When the flame they received from Messmer would not find purchase within them, the Fire Knights relied on fire incantations to honor their bond.\n\nEffect:\nLaunches a threaded serpentine flame",
+        "score": 0.4723092019557953,
+        "canonical_id": "spell:74",
+        "category": "spell",
+        "text_type": "description",
+        "source": "kaggle_dlc",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:description:2/2"
+      },
+      {
+        "lore_id": "armor:258::weighted_text_types_v1",
+        "text": "Impalers Excerpt:\nArmor of the Fire Knights under Messmer the Impaler's personal command.\nDistinguished by its red cape and twin golden snakes which adorn the neck, enhancing incantations of Messmer's flame.\nThese were the only ones who truly knew Messmer. His flames, like serpents. The painful fate that accompanied his accursed form.\n\nDescription:\nArmor of the Fire Knights under Messmer the Impaler's personal command. Distinguished by its red cape and twin golden snakes which adorn the neck, enhancing incantations of Messmer's flame. These were the only ones who truly knew Messmer. His flames, like serpents. The painful fate that accompanied his accursed form.",
+        "score": 0.5309450030326843,
+        "canonical_id": "armor:258",
+        "category": "armor",
+        "text_type": "impalers_excerpt",
+        "source": "kaggle_dlc|impalers",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:impalers_excerpt:2/2"
+      },
+      {
+        "lore_id": "npc:carian_speaker_310050000::weighted_text_types_v1",
+        "text": "Dialogue:\nAhh, the flame of chaos has nestled within you.",
+        "score": 0.43857985734939575,
+        "canonical_id": "npc:carian_speaker_310050000",
+        "category": "npc",
+        "text_type": "dialogue",
+        "source": "carian_dialogue_fmg",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:dialogue:2/2"
+      },
+      {
+        "lore_id": "item:140::weighted_text_types_v1",
+        "text": "Description:\nThis Ash of War grants an armament the Blood affinity and the following skill:\n\"Bloody Slash: Blood Oath skill granted by the Lord of Blood. From a low stance, coat the blade in your own blood to unleash a rending blood slash in a wide arc.\"\nUsable on swords (colossal weapons excepted).",
+        "score": 0.42383116483688354,
+        "canonical_id": "item:140",
+        "category": "item",
+        "text_type": "description",
+        "source": "carian_gem_fmg",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:description:3/2"
+      },
+      {
+        "lore_id": "armor:481::weighted_text_types_v1",
+        "text": "Impalers Excerpt:\nBlack helm of Messmer the Impaler, crowned with two intertwined winged serpents. Slightly enhances incantations of Messmer's fire as well as Fire Knight skills.\nThe winged snakes were Messmer's constant companions.\nThey were there when the base serpent was sealed away behind his eye. They were there through his eternity of suffering. They will accompany him yet, in his hideous new form born when he destroyed the grace granted by his mother. They have accepted his fate as much as he.\n\nDescription:\nBlack helm of Messmer the Impaler, crowned with two intertwined winged serpents. Slightly enhances incantations of Messmer's fire as well as Fire Knight skills.The winged snakes were Messmer's constant companions.They were there when the base serpent was sealed away behind his eye. They were there through his eternity of suffering. They will accompany him yet, in his hideous new form born when he destroyed the grace granted by his mother. They have accepted his fate as much as he.",
+        "score": 0.5305131673812866,
+        "canonical_id": "armor:481",
+        "category": "armor",
+        "text_type": "impalers_excerpt",
+        "source": "kaggle_dlc|impalers",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:impalers_excerpt:3/2"
+      },
+      {
+        "lore_id": "npc:carian_speaker_300900010::weighted_text_types_v1",
+        "text": "Dialogue:\nLet me be your serpent\u2026",
+        "score": 0.4368543028831482,
+        "canonical_id": "npc:carian_speaker_300900010",
+        "category": "npc",
+        "text_type": "dialogue",
+        "source": "carian_dialogue_fmg",
+        "reranker_score": null,
+        "ordering_notes": "balanced-slot:dialogue:3/2"
+      }
+    ],
+    "reranked": [
+      {
+        "lore_id": "spell:74::weighted_text_types_v1",
+        "text": "Description:\nIncantation of the Fire Knights under Messmer the Impaler's personal command. Launch a serpentine flame that bends and curls in pursuit of its foe. Charging enhances potency. When the flame they received from Messmer would not find purchase within them, the Fire Knights relied on fire incantations to honor their bond.\n\nEffect:\nLaunches a threaded serpentine flame",
+        "score": 0.4723092019557953,
+        "canonical_id": "spell:74",
+        "category": "spell",
+        "text_type": "description",
+        "source": "kaggle_dlc",
+        "reranker_score": 3.705937385559082,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:description:1/2"
+      },
+      {
+        "lore_id": "armor:480::weighted_text_types_v1",
+        "text": "Impalers Excerpt:\nBlack helm of Messmer the Impaler, crowned with two intertwined winged serpents.\nSlightly enhances incantations of Messmer's flame as well as Fire Knight skills.\nThe winged snakes were Messmer's constant companions.\nThey were there when the base serpent was sealed away behind his eye. They were there through his eternity of suffering. They will accompany him yet, in his hideous new form born when he destroyed the grace granted by his mother. They have accepted his fate as much as he.\n\nDescription:\nBlack helm of Messmer the Impaler, crowned with two intertwined winged serpents.Slightly enhances incantations of Messmer's flame as well as Fire Knight skills.The winged snakes were Messmer's constant companions.They were there when the base serpent was sealed away behind his eye. They were there through his eternity of suffering. They will accompany him yet, in his hideous new form born when he destroyed the grace granted by his mother. They have accepted his fate as much as he.",
+        "score": 0.5512473583221436,
+        "canonical_id": "armor:480",
+        "category": "armor",
+        "text_type": "impalers_excerpt",
+        "source": "kaggle_dlc|impalers",
+        "reranker_score": 4.257012367248535,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:impalers_excerpt:1/2"
+      },
+      {
+        "lore_id": "npc:carian_speaker_313033000::weighted_text_types_v1",
+        "text": "Dialogue:\nThe serpent that lurked in the shadows that night...",
+        "score": 0.41606563329696655,
+        "canonical_id": "npc:carian_speaker_313033000",
+        "category": "npc",
+        "text_type": "dialogue",
+        "source": "carian_dialogue_fmg",
+        "reranker_score": -9.032461166381836,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:dialogue:1/2"
+      },
+      {
+        "lore_id": "boss:77::weighted_text_types_v1",
+        "text": "Quote:\nThe great serpent of Mt. Gelmir that swallowed Praetor Rykard. Attacks with poisonous spit, bites, and slams.\n\nDrops:\nMt. Gelmir: Volcano Manor :; 130,000 Runes; Rykard's Great Rune; Remembrance of the Blasphemous",
+        "score": 0.41084057092666626,
+        "canonical_id": "boss:77",
+        "category": "boss",
+        "text_type": "quote",
+        "source": "kaggle_dlc",
+        "reranker_score": -8.832237243652344,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:quote:1/2"
+      },
+      {
+        "lore_id": "spell:149::weighted_text_types_v1",
+        "text": "Description:\nAn incantation of Messmer the Impaler. Summons Messmer's flame to form a giant floating orb. The orb soars toward a foe, crashes into the earth, and explodes after a brief delay. Charging enhances potency. Messmer despised his own fire. Time and time again he hoped to rid himself of it, but ever did it burn.\n\nEffect:\nShapes Messmer's flame into a giant orb that soars at foe",
+        "score": 0.5309575200080872,
+        "canonical_id": "spell:149",
+        "category": "spell",
+        "text_type": "description",
+        "source": "kaggle_dlc",
+        "reranker_score": 1.839914083480835,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:description:2/2"
+      },
+      {
+        "lore_id": "armor:258::weighted_text_types_v1",
+        "text": "Impalers Excerpt:\nArmor of the Fire Knights under Messmer the Impaler's personal command.\nDistinguished by its red cape and twin golden snakes which adorn the neck, enhancing incantations of Messmer's flame.\nThese were the only ones who truly knew Messmer. His flames, like serpents. The painful fate that accompanied his accursed form.\n\nDescription:\nArmor of the Fire Knights under Messmer the Impaler's personal command. Distinguished by its red cape and twin golden snakes which adorn the neck, enhancing incantations of Messmer's flame. These were the only ones who truly knew Messmer. His flames, like serpents. The painful fate that accompanied his accursed form.",
+        "score": 0.5309450030326843,
+        "canonical_id": "armor:258",
+        "category": "armor",
+        "text_type": "impalers_excerpt",
+        "source": "kaggle_dlc|impalers",
+        "reranker_score": 3.5324575901031494,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:impalers_excerpt:2/2"
+      },
+      {
+        "lore_id": "npc:carian_speaker_332002020::weighted_text_types_v1",
+        "text": "Dialogue:\nThen please. Kill the great serpent.",
+        "score": 0.42200830578804016,
+        "canonical_id": "npc:carian_speaker_332002020",
+        "category": "npc",
+        "text_type": "dialogue",
+        "source": "carian_dialogue_fmg",
+        "reranker_score": -9.061935424804688,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:dialogue:2/2"
+      },
+      {
+        "lore_id": "boss:151::weighted_text_types_v1",
+        "text": "Quote:\nJoin the Serpent King, as family... Together, we will devour the very gods!\n\nDrops:\nVolcano Manor: 130.000; Rykard's Great Rune; Remembrance of the Blasphemous",
+        "score": 0.4356585144996643,
+        "canonical_id": "boss:151",
+        "category": "boss",
+        "text_type": "quote",
+        "source": "kaggle_dlc",
+        "reranker_score": -10.39518928527832,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:quote:2/2"
+      },
+      {
+        "lore_id": "spell:185::weighted_text_types_v1",
+        "text": "Description:\nThe terrible power of Rykard, Lord of Blasphemy. Summons searing spirits that leave a trail of delayed explosions in their wake. These spirits manifest from the rancor of heroes who met a violent end. The lord granted them an audience, whereupon they were welcomed by the maw of the great serpent -- and within the serpent's bowels, they became the lord's kin. Note:\n\nEffect:\nReleases searing spirits that repeatedly explode after delay",
+        "score": 0.42364442348480225,
+        "canonical_id": "spell:185",
+        "category": "spell",
+        "text_type": "description",
+        "source": "kaggle_dlc",
+        "reranker_score": -9.021596908569336,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:description:3/2"
+      },
+      {
+        "lore_id": "armor:481::weighted_text_types_v1",
+        "text": "Impalers Excerpt:\nBlack helm of Messmer the Impaler, crowned with two intertwined winged serpents. Slightly enhances incantations of Messmer's fire as well as Fire Knight skills.\nThe winged snakes were Messmer's constant companions.\nThey were there when the base serpent was sealed away behind his eye. They were there through his eternity of suffering. They will accompany him yet, in his hideous new form born when he destroyed the grace granted by his mother. They have accepted his fate as much as he.\n\nDescription:\nBlack helm of Messmer the Impaler, crowned with two intertwined winged serpents. Slightly enhances incantations of Messmer's fire as well as Fire Knight skills.The winged snakes were Messmer's constant companions.They were there when the base serpent was sealed away behind his eye. They were there through his eternity of suffering. They will accompany him yet, in his hideous new form born when he destroyed the grace granted by his mother. They have accepted his fate as much as he.",
+        "score": 0.5305131673812866,
+        "canonical_id": "armor:481",
+        "category": "armor",
+        "text_type": "impalers_excerpt",
+        "source": "kaggle_dlc|impalers",
+        "reranker_score": 3.1463470458984375,
+        "ordering_notes": "reranker:cross_encoder; balanced-slot:impalers_excerpt:3/2"
+      }
+    ]
+  }
+}

--- a/pipeline/schemas.py
+++ b/pipeline/schemas.py
@@ -341,9 +341,7 @@ def get_dataset_schema(dataset_name: str) -> DataFrameSchema | None:
     return None
 
 
-def validate_dataframe(
-    df, schema: DataFrameSchema
-) -> tuple[bool, str | None, Any]:
+def validate_dataframe(df, schema: DataFrameSchema) -> tuple[bool, str | None, Any]:
     """Validate a DataFrame against a schema.
 
     Args:

--- a/src/corpus/cli.py
+++ b/src/corpus/cli.py
@@ -57,10 +57,7 @@ def fetch(
 ) -> None:
     """Fetch data from all configured sources."""
     if not settings.kaggle_credentials_set:
-        warning = (
-            "Warning: Kaggle credentials not set. "
-            "Kaggle datasets will be skipped."
-        )
+        warning = "Warning: Kaggle credentials not set. " "Kaggle datasets will be skipped."
         click.echo(warning, err=True)
 
     if fetch_all:
@@ -182,11 +179,7 @@ def load(
     """Load curated data into PostgreSQL."""
     try:
         dsn = dsn or settings.postgres_dsn
-        parquet_path = (
-            Path(parquet)
-            if parquet
-            else settings.curated_dir / "unified.parquet"
-        )
+        parquet_path = Path(parquet) if parquet else settings.curated_dir / "unified.parquet"
 
         if not parquet_path.exists():
             click.echo(

--- a/src/pipelines/build_lore_embeddings.py
+++ b/src/pipelines/build_lore_embeddings.py
@@ -57,6 +57,7 @@ DEFAULT_TEXT_TYPE_WEIGHTS: dict[str, float] = {
     "impalers_excerpt": 1.7,
     "quote": 1.3,
     "lore": 1.2,
+    "dialogue": 0.7,
     "effect": 0.7,
     "obtained_from": 0.8,
     "drops": 0.8,

--- a/src/pipelines/build_weapons_canonical.py
+++ b/src/pipelines/build_weapons_canonical.py
@@ -168,10 +168,14 @@ def _records_to_dataframe(records: list[dict[str, Any]]) -> pd.DataFrame:
     if frame.empty:
         raise RuntimeError("No canonical records remain after merging")
 
-    frame["source_priority"] = pd.to_numeric(
-        frame["source_priority"],
-        errors="coerce",
-    ).fillna(99).astype(int)
+    frame["source_priority"] = (
+        pd.to_numeric(
+            frame["source_priority"],
+            errors="coerce",
+        )
+        .fillna(99)
+        .astype(int)
+    )
 
     frame["is_dlc"] = frame["is_dlc"].fillna(False).astype(bool)
 
@@ -183,9 +187,7 @@ def _records_to_dataframe(records: list[dict[str, Any]]) -> pd.DataFrame:
     for column in SCALING_COLUMNS:
         if column not in frame.columns:
             frame[column] = "-"
-        frame[column] = (
-            frame[column].fillna("-").replace("", "-").astype(str).str.upper()
-        )
+        frame[column] = frame[column].fillna("-").replace("", "-").astype(str).str.upper()
 
     frame["weapon_type"] = frame["weapon_type"].fillna("other")
     if "provenance" not in frame.columns:
@@ -224,9 +226,7 @@ def _records_to_dataframe(records: list[dict[str, Any]]) -> pd.DataFrame:
         "provenance",
     ]
 
-    extra_columns = [
-        column for column in frame.columns if column not in column_order
-    ]
+    extra_columns = [column for column in frame.columns if column not in column_order]
     final_columns = column_order + extra_columns
 
     return frame.loc[:, final_columns]  # type: ignore[return-value]
@@ -238,9 +238,7 @@ def _resolve_description(bucket: Bucket) -> str | None:
     fallback_priority = _description_priority(bucket.best.get("source"))
 
     best_value = fallback_value
-    best_priority = (
-        fallback_priority if fallback_value else DEFAULT_DESCRIPTION_PRIORITY
-    )
+    best_priority = fallback_priority if fallback_value else DEFAULT_DESCRIPTION_PRIORITY
 
     for entry in bucket.entries:
         raw_value = entry.get("description")

--- a/src/rag/reranker.py
+++ b/src/rag/reranker.py
@@ -1,22 +1,49 @@
-"""Simple reranking interfaces for lore retrieval."""
+"""Reranking utilities for lore retrieval."""
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from dataclasses import dataclass
+import logging
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Protocol
+
+from corpus.config import settings
+
+try:  # pragma: no cover - optional dependency
+    from sentence_transformers import CrossEncoder
+except ImportError:  # pragma: no cover - handled at runtime
+    CrossEncoder = None
 
 if TYPE_CHECKING:  # pragma: no cover
     from rag.query import LoreMatch
+
+LOGGER = logging.getLogger(__name__)
 
 
 class RerankerProtocol(Protocol):
     """Protocol implemented by rerankers that reorder retrieved matches."""
 
-    def rerank(self, matches: Sequence["LoreMatch"]) -> list["LoreMatch"]:
+    candidate_pool_size: int | None
+
+    def rerank(
+        self,
+        query: str,
+        matches: Sequence[LoreMatch],
+    ) -> list[LoreMatch]:
         """Reorder the provided matches and return a new list."""
 
         raise NotImplementedError
+
+
+@dataclass(slots=True)
+class RerankerConfig:
+    """Configuration for reranker implementations."""
+
+    model_name: str
+    batch_size: int = 16
+    candidate_pool_size: int = 50
+    max_passages: int | None = None
+    device: str | None = None
 
 
 @dataclass(slots=True)
@@ -24,20 +51,128 @@ class IdentityReranker:
     """No-op reranker that keeps the original ordering."""
 
     name: str = "identity"
+    candidate_pool_size: int | None = None
 
-    def rerank(self, matches: Sequence["LoreMatch"]) -> list["LoreMatch"]:
+    def rerank(
+        self,
+        _: str,
+        matches: Sequence[LoreMatch],
+    ) -> list[LoreMatch]:
         return list(matches)
 
 
-def load_reranker(name: str | None) -> RerankerProtocol:
+_CrossEncoderFactory = Callable[[str, str | None], "CrossEncoder"]
+
+
+@dataclass(slots=True)
+class CrossEncoderReranker:
+    """Cross-encoder reranker powered by sentence-transformers."""
+
+    config: RerankerConfig
+    name: str = "cross_encoder"
+    candidate_pool_size: int | None = field(init=False)
+    _model: CrossEncoder | None = field(default=None, init=False)
+    _model_factory: _CrossEncoderFactory | None = field(
+        default=None,
+        init=False,
+    )
+
+    def __post_init__(self) -> None:
+        pool = max(0, self.config.candidate_pool_size)
+        self.candidate_pool_size = pool or None
+
+    def rerank(
+        self,
+        query: str,
+        matches: Sequence[LoreMatch],
+    ) -> list[LoreMatch]:
+        if not matches:
+            return []
+
+        model = self._load_model()
+        limit = min(
+            len(matches),
+            self.config.max_passages or self.config.candidate_pool_size,
+        )
+        limit = max(1, limit)
+        scored_slice = list(matches[:limit])
+        pairs = [(query, candidate.text) for candidate in scored_slice]
+        scores = model.predict(pairs, batch_size=self.config.batch_size)
+
+        scored_pairs: list[tuple[float, LoreMatch]] = []
+        for candidate, score in zip(scored_slice, scores, strict=False):
+            candidate.reranker_score = float(score)
+            _append_note(candidate, f"reranker:{self.name}")
+            scored_pairs.append((candidate.reranker_score, candidate))
+
+        scored_pairs.sort(key=lambda item: item[0], reverse=True)
+        reranked = [candidate for _, candidate in scored_pairs]
+        reranked.extend(matches[limit:])
+        return reranked
+
+    def _load_model(self) -> CrossEncoder:
+        if self._model is not None:
+            return self._model
+
+        factory = self._model_factory or _default_cross_encoder_factory
+        self._model = factory(self.config.model_name, self.config.device)
+        LOGGER.info(
+            "Loaded cross-encoder reranker model %s (device=%s)",
+            self.config.model_name,
+            self.config.device or "auto",
+        )
+        return self._model
+
+
+def _append_note(match: LoreMatch, note: str) -> None:
+    if not note:
+        return
+    existing = getattr(match, "ordering_notes", "")
+    match.ordering_notes = f"{existing}; {note}".strip("; ") if existing else note
+
+
+def _default_cross_encoder_factory(
+    model_name: str,
+    device: str | None,
+) -> CrossEncoder:  # pragma: no cover - thin wrapper
+    if CrossEncoder is None:  # pragma: no cover - defensive
+        msg = (
+            "sentence-transformers is required for cross-encoder reranking. "
+            "Install the 'embeddings-local' extra or add sentence-"
+            "transformers to your environment."
+        )
+        raise ImportError(msg)
+    kwargs = {"model_name": model_name}
+    if device:
+        kwargs["device"] = device
+    return CrossEncoder(**kwargs)
+
+
+def load_reranker(
+    name: str | None,
+    config: RerankerConfig | None = None,
+) -> RerankerProtocol:
     """Return a reranker implementation by name."""
 
-    normalized = (name or "identity").lower()
+    normalized = (name or settings.reranker_name or "identity").lower()
     if normalized in {"identity", "none"}:
         return IdentityReranker()
+    if normalized == "cross_encoder":
+        resolved = config or RerankerConfig(
+            model_name=settings.reranker_model,
+            batch_size=settings.reranker_batch_size,
+            candidate_pool_size=settings.reranker_candidate_pool,
+        )
+        return CrossEncoderReranker(config=resolved)
 
     msg = f"Unknown reranker: {name}"
     raise ValueError(msg)
 
 
-__all__ = ["IdentityReranker", "RerankerProtocol", "load_reranker"]
+__all__ = [
+    "CrossEncoderReranker",
+    "IdentityReranker",
+    "RerankerConfig",
+    "RerankerProtocol",
+    "load_reranker",
+]

--- a/tests/test_reranker.py
+++ b/tests/test_reranker.py
@@ -5,10 +5,11 @@
 from __future__ import annotations
 
 import pytest
-
 from rag.query import LoreMatch  # type: ignore[import]
 from rag.reranker import (  # type: ignore[import]
+    CrossEncoderReranker,
     IdentityReranker,
+    RerankerConfig,
     load_reranker,
 )
 
@@ -38,7 +39,7 @@ def _sample_matches() -> list[LoreMatch]:
 
 def test_identity_reranker_returns_copy() -> None:
     matches = _sample_matches()
-    reranked = IdentityReranker().rerank(matches)
+    reranked = IdentityReranker().rerank("query", matches)
 
     assert reranked == matches
     assert reranked is not matches
@@ -52,3 +53,54 @@ def test_load_reranker_handles_none_alias() -> None:
 def test_load_reranker_validates_names() -> None:
     with pytest.raises(ValueError):
         load_reranker("unknown")
+
+
+class _FakeCrossEncoder:
+    def __init__(self, scores: list[float]) -> None:
+        self._scores = scores
+        self.calls: list[tuple[str, str]] = []
+
+    def predict(
+        self,
+        pairs: list[tuple[str, str]],
+        *,
+        batch_size: int,
+    ) -> list[float]:
+        del batch_size
+        self.calls.extend(pairs)
+        return self._scores[: len(pairs)]
+
+
+def test_cross_encoder_reranker_orders_by_model_scores() -> None:
+    matches = _sample_matches() + [
+        LoreMatch(
+            lore_id="lore-3",
+            text="Third match",
+            score=0.6,
+            canonical_id="canon-3",
+            category="spell",
+            text_type="dialogue",
+            source="test",
+        )
+    ]
+    config = RerankerConfig(
+        model_name="unit-test",
+        batch_size=2,
+        candidate_pool_size=3,
+    )
+    reranker = CrossEncoderReranker(config=config)
+    fake_model = _FakeCrossEncoder([0.2, 0.9, 0.5])
+
+    def _factory(*_: object) -> _FakeCrossEncoder:
+        return fake_model
+
+    reranker._model_factory = _factory  # type: ignore[attr-defined]
+
+    reordered = reranker.rerank("query", matches)
+
+    assert [match.lore_id for match in reordered[:3]] == [
+        "lore-2",
+        "lore-3",
+        "lore-1",
+    ]
+    assert reranker.candidate_pool_size == 3

--- a/tests/test_weapons_canonical_pipeline.py
+++ b/tests/test_weapons_canonical_pipeline.py
@@ -92,9 +92,7 @@ def test_carian_fmg_loader_deduplicates_names(tmp_path: Path) -> None:
     )
 
     records = load_carian_weapon_fmg(raw_root)
-    assert {
-        record["name"] for record in records
-    } == {"Hand Axe", "Shadow Saber"}
+    assert {record["name"] for record in records} == {"Hand Axe", "Shadow Saber"}
 
     by_name = {record["name"]: record for record in records}
     assert by_name["Hand Axe"]["description"] == "FMG lore"


### PR DESCRIPTION
## Summary
- dampen dialogue weights and add the balanced/raw retrieval modes so default queries surface a healthier mix of Carian dialogue, descriptions, and Impalers excerpts
- integrate the configurable cross-encoder reranker throughout `rag.query`, persist reranker metadata, and expose new CLI flags with ordering annotations
- refresh docs/benchmarks plus add the reranker fixture JSON so Phase 4 & 5 acceptance criteria are fully documented

## Testing
- `poetry run ruff check --fix .`
- `poetry run ruff format .`
- `poetry run pytest`
